### PR TITLE
feat(engine): add Ticket live object and TicketConfig::resolve()

### DIFF
--- a/tix-engine/src/types/errors.rs
+++ b/tix-engine/src/types/errors.rs
@@ -14,6 +14,10 @@ pub enum TixError {
     ConfigNotFound(String),
     /// The repository was not found at the given path.
     RepoNotFound(String),
+    /// The ticket directory was not found at the given path.
+    TicketNotFound(String),
+    /// A worktree recorded in the ticket document was not found on disk.
+    WorktreeNotFound(String),
     /// A freeform error message.
     Message(String),
 }
@@ -27,6 +31,8 @@ impl fmt::Display for TixError {
             TixError::SerializationError(e) => write!(f, "serialization error: {}", e),
             TixError::ConfigNotFound(s) => write!(f, "config not found: {}", s),
             TixError::RepoNotFound(s) => write!(f, "repo not found: {}", s),
+            TixError::TicketNotFound(s) => write!(f, "ticket not found: {}", s),
+            TixError::WorktreeNotFound(s) => write!(f, "worktree not found: {}", s),
             TixError::Message(s) => write!(f, "{}", s),
         }
     }
@@ -124,6 +130,8 @@ mod tests {
             TixError::ParseError(parse_err),
             TixError::ConfigNotFound("path".into()),
             TixError::RepoNotFound("path".into()),
+            TixError::TicketNotFound("path".into()),
+            TixError::WorktreeNotFound("path".into()),
             TixError::Message("something went wrong".into()),
         ];
 

--- a/tix-engine/src/types/repository.rs
+++ b/tix-engine/src/types/repository.rs
@@ -1,7 +1,7 @@
-use crate::types::{errors::TixError, ticket::Ticket, worktree::Worktree};
+use crate::types::{errors::TixError, worktree::Worktree};
 use git2::{RepositoryState, WorktreeAddOptions};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::{debug, error, info, warn};
 
 /// The configuration for a repository.
@@ -150,10 +150,19 @@ impl Repository {
         }
     }
 
-    /// Creates a git worktree for the given ticket's branch at the ticket's path.
+    /// Creates a git worktree named `name` for `branch` at `path`.
+    ///
+    /// `name` is the worktree directory name under the ticket root — the key
+    /// of the worktree's entry in
+    /// [`TicketConfig::worktrees`](crate::TicketConfig::worktrees) — and
+    /// `path` is the full, already-resolved directory the worktree should
+    /// appear at. The engine takes both as given; deriving them from a ticket
+    /// is the frontend's job.
     ///
     /// Syncs the repository first (fetches and fast-forwards). Pass `force: true` to discard
-    /// local changes before syncing.
+    /// local changes before syncing. If `branch` exists locally the worktree
+    /// checks it out; otherwise git2 falls back to creating a fresh branch
+    /// named `name` from HEAD.
     ///
     /// # Errors
     ///
@@ -163,47 +172,60 @@ impl Repository {
     ///
     /// ```no_run
     /// # use tix_engine::RepositoryConfig;
-    /// # use tix_engine::Ticket;
     /// # use std::path::PathBuf;
     /// let repo = RepositoryConfig::new(
     ///     "https://github.com/owner/repo.git".to_string(),
     ///     PathBuf::from("/home/user/code/repo"),
     /// ).resolve("my-repo").unwrap();
-    /// let ticket = Ticket { key: "JIRA-123".into(), description: "Fix bug".into(), branch: "JIRA-123".into(), path: PathBuf::from("/home/user/tickets/JIRA-123"), worktrees: vec![] };
-    /// let worktree = repo.create_worktree(&ticket, false);
+    /// let worktree = repo.create_worktree(
+    ///     "my-repo",
+    ///     "feature/JIRA-123-fix-login",
+    ///     &PathBuf::from("/home/user/tickets/JIRA-123/my-repo"),
+    ///     false,
+    /// );
     /// ```
-    pub fn create_worktree(&self, ticket: &Ticket, force: bool) -> Result<Worktree, TixError> {
-        info!(alias = %self.alias, ticket = %ticket.key, branch = %ticket.branch, "creating worktree");
+    pub fn create_worktree(
+        &self,
+        name: &str,
+        branch: &str,
+        path: &Path,
+        force: bool,
+    ) -> Result<Worktree, TixError> {
+        info!(alias = %self.alias, name, branch, "creating worktree");
         self.sync(force)?;
 
-        let branch = self
-            .repo
-            .find_branch(&ticket.branch, git2::BranchType::Local)
-            .ok();
-        let reference = branch.map(|b| b.into_reference());
+        let local_branch = self.repo.find_branch(branch, git2::BranchType::Local).ok();
+        let reference = local_branch.map(|b| b.into_reference());
 
-        if let Some(parent) = ticket.path.parent() {
+        if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(TixError::IoError)?;
         }
 
         let mut options = WorktreeAddOptions::new();
         options.reference(reference.as_ref());
 
-        let worktree = self.repo.worktree(&ticket.branch, &ticket.path, Some(&options))
+        let worktree = self
+            .repo
+            .worktree(name, path, Some(&options))
             .map(|_| Worktree {
-                branch: ticket.branch.clone(),
+                name: name.to_string(),
+                branch: branch.to_string(),
                 repo_alias: self.alias.clone(),
-                path: ticket.path.clone(),
+                path: path.to_path_buf(),
             })
             .map_err(|e| {
-                error!(alias = %self.alias, ticket = %ticket.key, error = %e, "failed to create worktree");
+                error!(alias = %self.alias, name, error = %e, "failed to create worktree");
                 TixError::GitError(e)
             })?;
-        info!(alias = %self.alias, ticket = %ticket.key, path = %ticket.path.display(), "worktree created");
+        info!(alias = %self.alias, name, path = %path.display(), "worktree created");
         Ok(worktree)
     }
 
-    /// Prunes the git worktree for the given `branch` from this repository.
+    /// Prunes the git worktree registered as `name` from this repository.
+    ///
+    /// `name` is the worktree directory name — the same name the worktree was
+    /// created under via [`Self::create_worktree`], and the key of its entry
+    /// in [`TicketConfig::worktrees`](crate::TicketConfig::worktrees).
     ///
     /// Pass `force: true` to remove even if the worktree is in a dirty state. Without `force`,
     /// returns an error if the worktree fails validation (e.g. has uncommitted changes).
@@ -217,30 +239,23 @@ impl Repository {
     ///
     /// ```no_run
     /// # use tix_engine::RepositoryConfig;
-    /// # use tix_engine::Ticket;
     /// # use std::path::PathBuf;
     /// let repo = RepositoryConfig::new(
     ///     "https://github.com/owner/repo.git".to_string(),
     ///     PathBuf::from("/home/user/code/repo"),
     /// ).resolve("my-repo").unwrap();
-    /// let ticket = Ticket { key: "JIRA-123".into(), description: "Fix bug".into(), branch: "JIRA-123".into(), path: PathBuf::from("/home/user/tickets/JIRA-123"), worktrees: vec![] };
-    /// repo.remove_worktree(&ticket, "JIRA-123", false);
+    /// repo.remove_worktree("my-repo", false);
     /// ```
-    pub fn remove_worktree(
-        &self,
-        ticket: &Ticket,
-        branch: &str,
-        force: bool,
-    ) -> Result<(), TixError> {
-        info!(alias = %self.alias, ticket = %ticket.key, branch = %ticket.branch, "removing worktree");
+    pub fn remove_worktree(&self, name: &str, force: bool) -> Result<(), TixError> {
+        info!(alias = %self.alias, name, "removing worktree");
 
         let worktree = self
             .repo
-            .find_worktree(branch)
+            .find_worktree(name)
             .map_err(|_| TixError::from("worktree does not exist"))?;
 
         if !force && worktree.validate().is_err() {
-            error!(alias = %self.alias, ticket = %ticket.key, "worktree is dirty, use force to remove");
+            error!(alias = %self.alias, name, "worktree is dirty, use force to remove");
             return Err(TixError::from(
                 "worktree is not in a clean state, use force to remove",
             ));
@@ -250,10 +265,10 @@ impl Repository {
         opts.working_tree(true).valid(true);
 
         worktree.prune(Some(&mut opts)).map_err(|e| {
-            error!(alias = %self.alias, ticket = %ticket.key, error = %e, "failed to remove worktree");
+            error!(alias = %self.alias, name, error = %e, "failed to remove worktree");
             TixError::GitError(e)
         })?;
-        info!(alias = %self.alias, ticket = %ticket.key, "worktree removed");
+        info!(alias = %self.alias, name, "worktree removed");
         Ok(())
     }
 
@@ -556,12 +571,13 @@ mod tests {
         let local = test_helpers::clone_repo(&dir.path().join("remote"), &dir.path().join("local"));
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        let ticket = test_helpers::make_ticket("feature", &dir.path().join("worktrees/feature"));
-        let worktree = repo.create_worktree(&ticket, false).unwrap();
+        let path = dir.path().join("worktrees/feature");
+        let worktree = repo.create_worktree("feature", "feature", &path, false).unwrap();
 
+        assert_eq!(worktree.name, "feature");
         assert_eq!(worktree.branch, "feature");
-        assert_eq!(worktree.path, dir.path().join("worktrees/feature"));
-        assert!(dir.path().join("worktrees/feature").exists());
+        assert_eq!(worktree.path, path);
+        assert!(path.exists());
     }
 
     /// A ticket whose branch already exists locally reuses it and returns the correct `Worktree`.
@@ -578,11 +594,12 @@ mod tests {
         }
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        let ticket = test_helpers::make_ticket("feature", &dir.path().join("worktrees/feature"));
-        let worktree = repo.create_worktree(&ticket, false).unwrap();
+        let path = dir.path().join("worktrees/feature");
+        let worktree = repo.create_worktree("feature", "feature", &path, false).unwrap();
 
+        assert_eq!(worktree.name, "feature");
         assert_eq!(worktree.branch, "feature");
-        assert_eq!(worktree.path, dir.path().join("worktrees/feature"));
+        assert_eq!(worktree.path, path);
     }
 
     /// Creating a worktree with a name that already exists returns `TixError::GitError`.
@@ -594,11 +611,11 @@ mod tests {
         let local = test_helpers::clone_repo(&dir.path().join("remote"), &dir.path().join("local"));
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        let ticket = test_helpers::make_ticket("feature", &dir.path().join("worktrees/feature"));
-        repo.create_worktree(&ticket, false).unwrap();
+        let path = dir.path().join("worktrees/feature");
+        repo.create_worktree("feature", "feature", &path, false).unwrap();
 
         assert!(matches!(
-            repo.create_worktree(&ticket, false),
+            repo.create_worktree("feature", "feature", &path, false),
             Err(TixError::GitError(_))
         ));
     }
@@ -613,9 +630,8 @@ mod tests {
         test_helpers::make_mid_operation(&local);
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        let ticket = test_helpers::make_ticket("feature", &dir.path().join("worktrees/feature"));
         assert!(matches!(
-            repo.create_worktree(&ticket, false),
+            repo.create_worktree("feature", "feature", &dir.path().join("worktrees/feature"), false),
             Err(TixError::Message(_))
         ));
     }
@@ -631,10 +647,8 @@ mod tests {
         let local = test_helpers::clone_repo(&dir.path().join("remote"), &dir.path().join("local"));
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        let ticket =
-            test_helpers::make_ticket("nonexistent", &dir.path().join("worktrees/nonexistent"));
         assert!(matches!(
-            repo.remove_worktree(&ticket, "nonexistent", false),
+            repo.remove_worktree("nonexistent", false),
             Err(TixError::Message(_))
         ));
     }
@@ -649,9 +663,8 @@ mod tests {
         test_helpers::orphan_worktree(&local, "feature", &dir.path().join("worktrees/feature"));
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        let ticket = test_helpers::make_ticket("feature", &dir.path().join("worktrees/feature"));
         assert!(matches!(
-            repo.remove_worktree(&ticket, "feature", false),
+            repo.remove_worktree("feature", false),
             Err(TixError::Message(_))
         ));
     }
@@ -666,8 +679,7 @@ mod tests {
         test_helpers::orphan_worktree(&local, "feature", &dir.path().join("worktrees/feature"));
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        let ticket = test_helpers::make_ticket("feature", &dir.path().join("worktrees/feature"));
-        assert!(repo.remove_worktree(&ticket, "feature", true).is_ok());
+        assert!(repo.remove_worktree("feature", true).is_ok());
     }
 
     /// Removing a valid worktree succeeds and returns `Ok(())`.
@@ -680,8 +692,7 @@ mod tests {
         test_helpers::add_worktree(&local, "feature", &dir.path().join("worktrees/feature"));
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        let ticket = test_helpers::make_ticket("feature", &dir.path().join("worktrees/feature"));
-        assert!(repo.remove_worktree(&ticket, "feature", false).is_ok());
+        assert!(repo.remove_worktree("feature", false).is_ok());
         assert!(!dir.path().join("worktrees/feature").exists());
     }
 
@@ -859,7 +870,7 @@ mod tests {
 }
 
 #[cfg(test)]
-mod test_helpers {
+pub(crate) mod test_helpers {
     use super::*;
     use git2;
     use std::path::Path;
@@ -966,17 +977,6 @@ mod test_helpers {
 
         std::fs::remove_dir_all(path).unwrap();
         worktree
-    }
-
-    /// Constructs a minimal [`Ticket`] with the given `branch` and `path`.
-    pub fn make_ticket(branch: &str, path: &Path) -> Ticket {
-        Ticket {
-            key: branch.to_string(),
-            description: "".to_string(),
-            branch: branch.to_string(),
-            path: path.to_path_buf(),
-            worktrees: Vec::new(),
-        }
     }
 
     /// Creates `branch` on the bare remote without creating it locally,

--- a/tix-engine/src/types/ticket.rs
+++ b/tix-engine/src/types/ticket.rs
@@ -1,8 +1,9 @@
-use crate::types::repository::Repository;
+use crate::types::errors::TixError;
 use crate::types::worktree::{Worktree, WorktreeConfig};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use tracing::{debug, error};
 
 /// The `[ticket]` section of the ticket document (`.tix/ticket.toml`).
 ///
@@ -77,55 +78,273 @@ pub struct TicketConfig {
     pub worktrees: HashMap<String, WorktreeConfig>,
 }
 
-/// A work item with one or more git worktrees sharing a common branch.
-#[derive(Serialize, Debug)]
+impl TicketConfig {
+    /// Validates this config against disk and returns a live [`Ticket`].
+    ///
+    /// `path` is the ticket workspace directory (the parent of `.tix/`),
+    /// already resolved by the frontend — the engine does no discovery. Every
+    /// entry in [`Self::worktrees`] is verified: its directory must exist
+    /// under `path` and be openable as a git worktree. Untracked directories
+    /// under the ticket root are ignored — scratch space is allowed.
+    ///
+    /// `resolve()` promises validity: if you hold a [`Ticket`], its directory
+    /// and every recorded worktree existed at resolution time. Frontends
+    /// resolve per command, use the result, and discard it.
+    ///
+    /// # Errors
+    ///
+    /// - [`TixError::TicketNotFound`] if `path` does not exist or is not a
+    ///   directory
+    /// - [`TixError::WorktreeNotFound`] if a recorded worktree's directory is
+    ///   missing
+    /// - [`TixError::GitError`] if a recorded worktree's directory exists but
+    ///   cannot be opened as a git repository
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use tix_engine::TicketConfig;
+    /// # use std::path::PathBuf;
+    /// # fn main() -> Result<(), tix_engine::TixError> {
+    /// let config: TicketConfig = toml::from_str(
+    ///     r#"
+    ///     key = "JIRA-123"
+    ///     description = "Fix the login bug"
+    ///
+    ///     [worktrees.backend]
+    ///     repo = "backend"
+    ///     branch = "feature/JIRA-123-fix-login"
+    ///     "#,
+    /// )
+    /// .unwrap();
+    ///
+    /// let ticket = config.resolve(PathBuf::from("/home/user/tickets/JIRA-123"))?;
+    /// for worktree in ticket.worktrees() {
+    ///     println!("{} → {}", worktree.name, worktree.branch);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn resolve(self, path: PathBuf) -> Result<Ticket, TixError> {
+        debug!(key = %self.key, path = %path.display(), "resolving ticket");
+        if !path.is_dir() {
+            error!(key = %self.key, path = %path.display(), "ticket directory does not exist");
+            return Err(TixError::TicketNotFound(path.display().to_string()));
+        }
+
+        // Sort by name so the resulting Vec is deterministic — HashMap
+        // iteration order is not.
+        let mut entries: Vec<(&String, &WorktreeConfig)> = self.worktrees.iter().collect();
+        entries.sort_by(|a, b| a.0.cmp(b.0));
+
+        let mut worktrees = Vec::with_capacity(entries.len());
+        for (name, entry) in entries {
+            let worktree_path = path.join(name);
+            if !worktree_path.is_dir() {
+                error!(key = %self.key, worktree = %name, path = %worktree_path.display(), "recorded worktree is missing on disk");
+                return Err(TixError::WorktreeNotFound(format!(
+                    "'{}' recorded in ticket '{}' but missing at {}",
+                    name,
+                    self.key,
+                    worktree_path.display()
+                )));
+            }
+            // The directory must actually be a git worktree, not just any
+            // directory that happens to share the recorded name.
+            git2::Repository::open(&worktree_path).map_err(|e| {
+                error!(key = %self.key, worktree = %name, error = %e, "recorded worktree is not a git repository");
+                TixError::GitError(e)
+            })?;
+            worktrees.push(Worktree {
+                name: name.clone(),
+                repo_alias: entry.repo.clone(),
+                branch: entry.branch.clone(),
+                path: worktree_path,
+            });
+        }
+
+        debug!(key = %self.key, worktrees = worktrees.len(), "ticket resolved");
+        Ok(Ticket {
+            config: self,
+            path,
+            worktrees,
+        })
+    }
+}
+
+/// A live, validated ticket.
+///
+/// If you hold a `Ticket`, it is valid: the ticket directory exists and every
+/// worktree recorded in its [`TicketConfig`] was present on disk at resolution
+/// time. Construct one via [`TicketConfig::resolve`]; frontends resolve what
+/// they need per command, use it, and discard it.
+///
+/// `Ticket` is deliberately not serializable — it is a live object, not
+/// stored state. The stored form is [`TicketConfig`].
+#[derive(Debug)]
 pub struct Ticket {
-    /// An identifier for the ticket (e.g. `JIRA-123`).
-    pub key: String,
-    /// A human-readable description of the ticket.
-    pub description: String,
-    /// The branch name shared by all worktrees in this ticket.
-    pub branch: String,
+    /// The `[ticket]` section this ticket was resolved from.
+    pub config: TicketConfig,
     /// The path to the ticket workspace directory.
     pub path: PathBuf,
-    /// The [`Worktree`] associated with this ticket.
-    pub worktrees: Vec<Worktree>,
+    /// The verified live worktrees, in worktree-name order.
+    worktrees: Vec<Worktree>,
 }
 
 impl Ticket {
-    /// Creates a new `Ticket`.
-    fn new(
-        key: String,
-        description: String,
-        branch: String,
-        path: PathBuf,
-        worktrees: Vec<Worktree>,
-    ) -> Self {
-        // TODO: ensure path exists
-        // TODO: resolve branch from key and description
-        Self {
-            key,
-            branch,
-            description,
-            path,
-            worktrees,
-        }
-    }
-
-    /// Adds a worktree for `repo` to this ticket.
-    fn add(repo: Repository) -> Option<PathBuf> {
-        todo!("add repo to ticket")
-    }
-
-    /// Removes the worktree for `repo` from this ticket.
-    fn remove(repo: Repository) -> Option<PathBuf> {
-        todo!("remove from a ticket")
+    /// The verified live worktrees of this ticket, sorted by worktree name.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use tix_engine::TicketConfig;
+    /// # use std::path::PathBuf;
+    /// # fn main() -> Result<(), tix_engine::TixError> {
+    /// # let config: TicketConfig = toml::from_str(r#"
+    /// # key = "JIRA-123"
+    /// # description = "Fix the login bug"
+    /// # "#).unwrap();
+    /// let ticket = config.resolve(PathBuf::from("/home/user/tickets/JIRA-123"))?;
+    /// for worktree in ticket.worktrees() {
+    ///     println!("{}", worktree.path.display());
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn worktrees(&self) -> &[Worktree] {
+        &self.worktrees
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::repository::test_helpers;
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    /// Builds a real git repo and a worktree of it at `ticket_root/<name>` on
+    /// branch `<name>`, returning a `TicketConfig` entry-compatible pair.
+    fn setup_worktree(dir: &Path, name: &str, ticket_root: &Path) {
+        let remote_path = dir.join(format!("{name}-remote"));
+        let local_path = dir.join(format!("{name}-local"));
+        let remote = test_helpers::init_bare_repo(&remote_path);
+        test_helpers::add_commit_to_bare(&remote, "initial commit");
+        let local = test_helpers::clone_repo(&remote_path, &local_path);
+        test_helpers::add_worktree(&local, name, &ticket_root.join(name));
+    }
+
+    fn config_with(worktrees: &[(&str, &str, &str)]) -> TicketConfig {
+        TicketConfig {
+            key: "JIRA-123".to_string(),
+            description: "Fix the login bug".to_string(),
+            worktrees: worktrees
+                .iter()
+                .map(|(name, repo, branch)| {
+                    (
+                        name.to_string(),
+                        WorktreeConfig {
+                            repo: repo.to_string(),
+                            branch: branch.to_string(),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    // --- resolve ---
+
+    /// A ticket directory with every recorded worktree present resolves into a
+    /// live `Ticket` carrying verified worktrees in name order.
+    #[test]
+    fn test_resolve_valid() {
+        let dir = tempdir().unwrap();
+        let ticket_root = dir.path().join("ticket");
+        std::fs::create_dir_all(&ticket_root).unwrap();
+        setup_worktree(dir.path(), "backend", &ticket_root);
+        setup_worktree(dir.path(), "frontend", &ticket_root);
+
+        let config = config_with(&[
+            ("frontend", "frontend", "frontend"),
+            ("backend", "backend", "backend"),
+        ]);
+        let ticket = config.clone().resolve(ticket_root.clone()).unwrap();
+
+        assert_eq!(ticket.config, config);
+        assert_eq!(ticket.path, ticket_root);
+        let names: Vec<&str> = ticket.worktrees().iter().map(|w| w.name.as_str()).collect();
+        assert_eq!(names, vec!["backend", "frontend"]);
+        assert_eq!(ticket.worktrees()[0].repo_alias, "backend");
+        assert_eq!(ticket.worktrees()[0].path, ticket_root.join("backend"));
+    }
+
+    /// A missing ticket directory errors with `TicketNotFound`.
+    #[test]
+    fn test_resolve_missing_ticket_dir() {
+        let dir = tempdir().unwrap();
+        let config = config_with(&[]);
+        assert!(matches!(
+            config.resolve(dir.path().join("nonexistent")),
+            Err(TixError::TicketNotFound(_))
+        ));
+    }
+
+    /// A recorded worktree whose directory is missing errors with
+    /// `WorktreeNotFound` — resolve() promises validity.
+    #[test]
+    fn test_resolve_missing_recorded_worktree() {
+        let dir = tempdir().unwrap();
+        let ticket_root = dir.path().join("ticket");
+        std::fs::create_dir_all(&ticket_root).unwrap();
+
+        let config = config_with(&[("backend", "backend", "feature/x")]);
+        assert!(matches!(
+            config.resolve(ticket_root),
+            Err(TixError::WorktreeNotFound(_))
+        ));
+    }
+
+    /// A recorded worktree whose directory exists but is not a git repository
+    /// errors with `GitError`.
+    #[test]
+    fn test_resolve_recorded_worktree_not_git() {
+        let dir = tempdir().unwrap();
+        let ticket_root = dir.path().join("ticket");
+        std::fs::create_dir_all(ticket_root.join("backend")).unwrap();
+
+        let config = config_with(&[("backend", "backend", "feature/x")]);
+        assert!(matches!(
+            config.resolve(ticket_root),
+            Err(TixError::GitError(_))
+        ));
+    }
+
+    /// Untracked directories under the ticket root are ignored — scratch
+    /// space is allowed.
+    #[test]
+    fn test_resolve_ignores_untracked_directories() {
+        let dir = tempdir().unwrap();
+        let ticket_root = dir.path().join("ticket");
+        std::fs::create_dir_all(ticket_root.join("scratch-notes")).unwrap();
+        setup_worktree(dir.path(), "backend", &ticket_root);
+
+        let config = config_with(&[("backend", "backend", "backend")]);
+        let ticket = config.resolve(ticket_root).unwrap();
+        assert_eq!(ticket.worktrees().len(), 1);
+    }
+
+    /// A ticket with no recorded worktrees resolves to a live ticket with an
+    /// empty worktree list.
+    #[test]
+    fn test_resolve_empty_worktrees() {
+        let dir = tempdir().unwrap();
+        let ticket_root = dir.path().join("ticket");
+        std::fs::create_dir_all(&ticket_root).unwrap();
+
+        let ticket = config_with(&[]).resolve(ticket_root).unwrap();
+        assert!(ticket.worktrees().is_empty());
+    }
 
     fn sample_config() -> TicketConfig {
         let mut worktrees = HashMap::new();

--- a/tix-engine/src/types/worktree.rs
+++ b/tix-engine/src/types/worktree.rs
@@ -36,9 +36,18 @@ pub struct WorktreeConfig {
     pub branch: String,
 }
 
-/// A git worktree associated with a repository and ticket branch.
+/// A live git worktree associated with a repository and ticket branch.
+///
+/// Produced by [`TicketConfig::resolve`](crate::TicketConfig::resolve) (from
+/// recorded state verified against disk) or by
+/// [`Repository::create_worktree`](crate::Repository::create_worktree) (from a
+/// worktree it just created). Holding one means the worktree existed at the
+/// time it was produced.
 #[derive(Serialize, Debug, Clone, PartialEq)]
 pub struct Worktree {
+    /// The worktree directory name under the ticket root — the key of this
+    /// worktree's entry in [`TicketConfig::worktrees`](crate::TicketConfig::worktrees).
+    pub name: String,
     /// The alias of the repository.
     pub repo_alias: String,
     /// The path to the worktree directory.


### PR DESCRIPTION
Closes #58

Stacked on #106 (base: `armaan/ticketconfig-56`).

- `TicketConfig::resolve(self, path) -> Result<Ticket, TixError>`: verifies the ticket dir exists, verifies each recorded worktree's directory exists **and** opens as a git repo, populates `Worktree`s (name, repo alias, branch, path) sorted by name for determinism. Untracked dirs under the ticket root are ignored (scratch space allowed).
- `Ticket { pub config, pub path, worktrees }` with private `worktrees` + accessor; no `Serialize` (live object), no single `branch` field. Old `new`/`add`/`remove` stubs removed — that surface returns with #80/#81 driven by the CLI.
- **Repository signature changes** (necessitated by `Ticket.branch` going away): `create_worktree(name, branch, path, force)` and `remove_worktree(name, force)` take resolved values instead of `&Ticket`. Worktrees are now registered under their **name** rather than their branch — with per-worktree branches a branch is no longer a unique worktree handle.
- `Worktree` gains `name` (the `TicketConfig::worktrees` map key).
- New `TixError::TicketNotFound` / `TixError::WorktreeNotFound` variants.
- resolve() covered by 6 tests against real git repos; docs with examples throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)