### PR TITLE
feat(engine): add Defaults section type for creation-time seeds

### DIFF
--- a/tix-engine/src/lib.rs
+++ b/tix-engine/src/lib.rs
@@ -12,6 +12,8 @@
 //!   where ticket directories are stored, and which repositories are registered.
 //! - A [`RepositoryConfig`] is a registered source repository.
 //!   Resolving one produces a [`Repository`] backed by a local git clone.
+//! - A [`Defaults`] is the `[defaults]` section of the global config: seed
+//!   values read once at ticket creation, never resolved at runtime.
 //! - A [`TicketConfig`] is the `[ticket]` section of a ticket document
 //!   (`.tix/ticket.toml`): the ticket's identity plus a map of worktree
 //!   directory name → [`WorktreeConfig`] recording each worktree's repository
@@ -29,6 +31,7 @@ mod types;
 mod utils;
 
 pub use types::config::Config;
+pub use types::defaults::Defaults;
 pub use types::errors::TixError;
 pub use types::repository::Repository;
 pub use types::repository::RepositoryConfig;

--- a/tix-engine/src/types/defaults.rs
+++ b/tix-engine/src/types/defaults.rs
@@ -1,0 +1,125 @@
+use serde::{Deserialize, Serialize};
+
+/// The `[defaults]` section of the global config — **seeds, not defaults**.
+///
+/// Values here are read **once** by `tix ticket setup` at ticket creation and
+/// written into the ticket document. Changing a global value later affects
+/// only new tickets; there is no runtime override/fallback resolver anywhere
+/// in tix. Anything that shapes git state must be a seed — topology on disk
+/// cannot be retroactively rewritten by config (see `design/spec.md` §3.4).
+///
+/// Every field is optional in the document: a partial (or absent) `[defaults]`
+/// section is normal, and [`Default`] gives the all-empty value for the
+/// `section_or_default` read path.
+///
+/// The field set adopts v2's provisionally and may expand or retract as
+/// `tix ticket setup` takes shape.
+///
+/// # Examples
+///
+/// A partial `[defaults]` section parses; unset fields stay `None`/empty:
+///
+/// ```
+/// # use tix_engine::Defaults;
+/// let defaults: Defaults = toml::from_str(
+///     r#"
+///     branch_prefix = "feature"
+///     repositories = ["backend", "frontend"]
+///     "#,
+/// )
+/// .unwrap();
+///
+/// assert_eq!(defaults.branch_prefix.as_deref(), Some("feature"));
+/// assert_eq!(defaults.repositories, vec!["backend", "frontend"]);
+/// assert!(defaults.github_base_url.is_none());
+/// assert!(defaults.default_repository_owner.is_none());
+/// ```
+///
+/// An empty document is the same as no section at all:
+///
+/// ```
+/// # use tix_engine::Defaults;
+/// let defaults: Defaults = toml::from_str("").unwrap();
+/// assert_eq!(defaults, Defaults::default());
+/// ```
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct Defaults {
+    /// Seed for branch name derivation at `tix ticket setup`:
+    /// `<prefix>/<key>-<sanitized-description>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch_prefix: Option<String>,
+    /// Seed for remote URL construction.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github_base_url: Option<String>,
+    /// Seed for remote URL construction: the owner used when a repository is
+    /// given without one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_repository_owner: Option<String>,
+    /// Which registered repositories a new ticket includes.
+    ///
+    /// This is *what to seed a new ticket with* — a different field from the
+    /// ticket document's worktree map (*what the ticket has*), not an
+    /// override pair.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub repositories: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_defaults() -> Defaults {
+        Defaults {
+            branch_prefix: Some("feature".to_string()),
+            github_base_url: Some("https://github.mycompany.com".to_string()),
+            default_repository_owner: Some("my-org".to_string()),
+            repositories: vec!["backend".to_string(), "frontend".to_string()],
+        }
+    }
+
+    /// A fully populated `[defaults]` section deserializes correctly.
+    #[test]
+    fn test_deserialize_full_section() {
+        let toml = r#"
+branch_prefix = "feature"
+github_base_url = "https://github.mycompany.com"
+default_repository_owner = "my-org"
+repositories = ["backend", "frontend"]
+"#;
+        let defaults: Defaults = toml::from_str(toml).unwrap();
+        assert_eq!(defaults, sample_defaults());
+    }
+
+    /// Serializing and deserializing preserves all data.
+    #[test]
+    fn test_round_trip() {
+        let defaults = sample_defaults();
+        let restored: Defaults = toml::from_str(&toml::to_string(&defaults).unwrap()).unwrap();
+        assert_eq!(restored, defaults);
+    }
+
+    /// Unset optional fields serialize to nothing rather than explicit nulls,
+    /// so a default value round-trips through an empty document.
+    #[test]
+    fn test_default_serializes_empty() {
+        assert_eq!(toml::to_string(&Defaults::default()).unwrap(), "");
+    }
+
+    /// An empty document parses to the all-empty `Default` value.
+    #[test]
+    fn test_empty_section() {
+        let defaults: Defaults = toml::from_str("").unwrap();
+        assert_eq!(defaults, Defaults::default());
+    }
+
+    /// Unknown fields in the `[defaults]` section are rejected.
+    #[test]
+    fn test_rejects_unknown_fields() {
+        let toml = r#"
+branch_prefix = "feature"
+base_branch = "not-a-seed-we-know"
+"#;
+        assert!(toml::from_str::<Defaults>(toml).is_err());
+    }
+}

--- a/tix-engine/src/types/mod.rs
+++ b/tix-engine/src/types/mod.rs
@@ -1,6 +1,9 @@
 /// Types related to Tix configuration and errors.
 pub mod config;
 
+/// The `[defaults]` section of the global config — seeds read at ticket creation.
+pub mod defaults;
+
 /// Types related to Tix errors.
 pub mod errors;
 


### PR DESCRIPTION
Part of #97 — the engine half (shape + serde only). The seed **reads** at ticket creation land with `tix ticket setup` (#77), which should close #97.

Stacked on #107 (base: `armaan/ticket-resolve-58`).

- `Defaults` in `types/defaults.rs`: `branch_prefix`, `github_base_url`, `default_repository_owner` (all `Option<String>`), `repositories: Vec<String>` — v2's provisional set per spec §3.4
- `deny_unknown_fields`; every field `#[serde(default)]` so a partial `[defaults]` parses; unset fields skip serialization so `Default` round-trips through an empty document
- Docs spell out seeds-not-defaults (read once at creation, no runtime resolver) and that `defaults.repositories` vs the ticket worktree map are different fields, not an override pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)