### PR TITLE
docs(design): commit v3 crate architecture design and normative spec

### DIFF
--- a/design/2026-07-18.md
+++ b/design/2026-07-18.md
@@ -1,0 +1,652 @@
+# Crate architecture
+
+Status: design settled, not implemented. Supersedes the earlier
+`plugin-architecture.md` scratch note.
+
+One line per crate:
+
+- **`tix-engine`** — git2 operations over resolved paths.
+- **`tix-cli`** — how the CLI performs those operations.
+- **`tix-sdk`** — `tix-cli`'s context-and-consistency layer, deliberately
+  coupled to it and shipped separately so plugins inherit the same
+  behavior for free.
+
+## Background
+
+Rust has no `importlib`-style dynamic import — no stable ABI, no runtime
+reflection. Plugins are external subprocesses, git/cargo-style: the CLI
+discovers `tix-<name>` binaries on `PATH` and execs them, forwarding
+user-facing args. `tix-cli/src/tix/plugin.rs` already stubs this
+(`Commands::External(args) => plugin::run(args)`).
+
+This also makes non-Rust plugins work without extra machinery: a Python
+package ships a `console_scripts` entry point named `tix-foo` and lands on
+`PATH` like any Rust plugin.
+
+## Goal
+
+Split the generalized, CLI-shaped helpers that `tix-cli` develops into
+their own crate. `tix-cli` needs that context-and-consistency layer
+regardless of whether plugins ever exist; making it a crate means plugins
+get it too. The layering by **consumer role**:
+
+- **New frontends** (GUI, TUI, anything non-CLI) → `tix-engine` only, or
+  `tix-sdk` too if they want tix's layout conventions rather than
+  their own.
+- **`tix-cli`** → the canonical frontend. The reference implementation of
+  the engine, and the SDK's primary consumer.
+- **Plugins** → `tix-sdk`. A bonus that falls out of the split.
+
+The SDK is *extracted from* the canonical frontend rather than designed
+independently for plugins: `tix-cli` grows a helper, it gets generalized,
+it moves to the SDK, plugins get it for free. That is why the SDK's
+surface expands opportunistically instead of being specified up front.
+
+### Promotion criterion
+
+If something is consistently annoying to get wrong, or keeps getting
+repeated, it wants to move up the tree — someone else will hit the same
+problem. Two independent axes:
+
+- **Annoyance** decides *whether* to promote.
+- **Shape** decides *where it lands*, and the boundary is location policy:
+  - **`tix-engine`** — domain operations over *already-resolved* paths. It
+    has no opinion on where a frontend puts config, tickets, or code.
+    Discovery, resolution, and layout are frontend implementation details
+    and must not leak in.
+  - **`tix-sdk`** — frontend policy that plugins have to agree with
+    the canonical frontend about: the invocation contract, config
+    discovery and parsing, typed section access, ticket discovery.
+
+`tix-cli` is where that policy is written first; the SDK is the promoted
+subset. A frontend that wants tix's conventions can depend on the SDK for
+them; one that wants its own layout takes `tix-engine` alone.
+
+Concretely, the host resolves context — which ticket am I in, where is
+config — and hands it over. Config parsing was never the interesting part;
+ticket discovery is, since that walk has real edge cases (nesting,
+symlinks, ceilings) and must have exactly one implementation.
+
+## Crate structure
+
+- **`tix-engine`** — core domain crate. `serde`, `toml`, `git2`,
+  `EngineConfig`/`RepositoryConfig`/`TicketConfig`. No `clap`. Name kept; no
+  rename to `libtix` (a C-ism — Cargo already distinguishes lib from bin).
+- **`tix-sdk`** (new) — depends on `clap` + `tix-engine`. Owns the
+  invocation contract: parses host-injected flags, parses the config
+  documents, and owns the typed section accessors.
+
+  **`tix-sdk` and `tix-cli` are deliberately coupled.** This is not a
+  neutral general-purpose library that `tix-cli` happens to use — it is
+  `tix-cli`'s own context-and-consistency layer, which lives in a separate
+  crate so it can be shared. Features land in the SDK *because the CLI
+  wants them applied consistently*; plugins then get them by default. The
+  demand direction is always CLI → SDK, never a guess at what plugins
+  might want.
+
+  That coupling is also what keeps the SDK honest: it cannot quietly rot,
+  because breaking it breaks the canonical frontend immediately.
+- **`tix-cli`** — unchanged name/binary (`tix`). Depends on `tix-sdk`
+  only.
+
+**Dependency stack:** `{tix-cli, pytix} → tix-sdk → tix-engine`. A linear
+chain, not a diamond — which requires `tix-sdk` to **re-export
+`tix-engine`**, since `tix-cli` names `Repository`/`Ticket`/`Worktree`
+constantly and would otherwise need its own engine edge. Re-exporting
+(tokio/axum style) makes the lockstep versioning structurally true rather
+than merely conventional. Non-CLI frontends that want no layout policy may
+still depend on `tix-engine` directly — a deliberate bypass of the chain,
+not a violation of it.
+- **`pytix`** — the only plugin-motivated crate in the workspace, and the
+  one piece designed on spec rather than extracted from `tix-cli`. Its
+  `pytix.host` surface is plugin-specific; the engine bindings are
+  general-purpose scripting that plugins also happen to use. Safe to defer
+  until a real Python plugin exists to shape it (already last in
+  sequencing). PyO3 bindings, single wheel. Always compiles in bindings
+  for both crates (no Cargo feature gating, no pip extras — a wheel is
+  built once and extras cannot vary compiled content). Namespaced at the
+  Python level:
+  - `pytix.*` — engine bindings
+  - `pytix.host` — `tix-sdk` bindings. Named `host` because the module
+    *is* the plugin's handle on the invoking host; `pytix.cli` was
+    rejected since "cli" already denotes the host binary (`tix-cli`)
+    elsewhere in the workspace.
+
+**Versioning:** crates stay in lockstep, as a consequence rather than a
+policy. They are coupled by design and chained by re-export, so
+independent versions were never available — a `tix-sdk` release implies
+the `tix-engine` it re-exports, and `tix-cli` is the canonical
+implementation of both. They build and release together.
+
+Crate versions therefore govern nothing about compatibility. The only
+place two separately-compiled artifacts meet is host ↔ plugin, and that
+boundary is governed entirely by `--tix-protocol` (see below). A plugin
+built against `tix-sdk` 3.1.0 and run by a `tix` 3.4.0 host is fine or
+broken based on the protocol integer alone; the crate versions say
+nothing about it. That is why both numbers exist and why they are
+unrelated.
+
+Patch-level drift only becomes a meaningful concept if the crates are
+ever published separately and consumers pin them independently. Until
+then it is not a question worth answering.
+
+## Config model
+
+Two documents, **not** two layers of one schema. They describe different
+things and mostly do not overlap, so there is no general TOML merge.
+
+- **Global config** — the environment: directories, defaults, the
+  registered repository map. Discovered via `dirs`.
+- **Ticket-local config** — `.tix/ticket.toml` inside a ticket dir: ticket
+  identity, description, which repos are contained, and **a branch per
+  repo**.
+
+  Per-repo branches, not one shared branch: v2's `TicketMetadata` carried
+  `repo_branches: HashMap<alias, branch>` and `repo_worktrees:
+  HashMap<alias, sanitized_name>`, so repos in one ticket could sit on
+  different branches. v3's current `Ticket.branch: String` loses that and
+  is an oversight to correct — `lib.rs` already describes worktrees
+  sharing a common branch *prefix*, not a common branch.
+
+  (v2 named this file `.tix/info.toml`. The rename is a v2→v3 migration
+  concern, deferred until parity.)
+
+### Documents and sections
+
+Each document is a set of **sections**, one per consumer. Global config
+holds `[engine]`, `[cli]`, and a `[<plugin>]` table per plugin; the ticket
+document holds `[ticket]` and per-plugin tables for per-ticket state.
+
+**There is no top-level typed struct.** Today `Config` wraps
+`engine: Engine` and stands for the whole document — but if `[cli]` grows
+a section, `Config` needs a `cli` field, which drags CLI types into
+`tix-engine` and breaks the layering. So `Engine` becomes `EngineConfig`,
+a *section* type exported from `tix-engine`, and the document level is the
+SDK's generic parsed tree. `TicketConfig` (already in
+`tix-engine/src/types/ticket.rs`) is likewise the `[ticket]` section, not
+the ticket document.
+
+### Resolving a document into objects
+
+Two stages. The split is the whole design.
+
+**Stage 1 — locate and parse. Identical for every consumer, owned by the
+SDK.** The path comes from discovery (`tix-cli`) or from
+`--tix-config`/`--tix-ticket` (plugin). Read, parse into a generic
+format-preserving document. No types are involved; every section is
+present as an untyped subtree.
+
+**Stage 2 — extract typed sections on demand, by whoever owns the type.**
+
+```rust
+let doc = ctx.global();                              // parsed, untyped
+let engine: EngineConfig = doc.section("engine")?;   // tix-engine's type
+let cli:    CliConfig    = doc.section("cli")?;      // tix-cli's type
+let mine:   MyPluginCfg  = doc.section("myplugin")?; // the plugin's type
+```
+
+Each consumer deserializes only the subtree it has a type for.
+`deny_unknown_fields` on that type applies to that subtree alone — the
+behavior `tix-engine/src/types/config.rs` already has, made explicit
+rather than implicit in a whole-document struct.
+
+A missing section is normal (a plugin's first run has no table yet), so
+the SDK offers both forms — `section::<T>() -> Option<T>` and
+`section_or_default::<T>() -> T` where `T: Default`. "Absent" and "empty"
+are meaningfully different for some consumers and not others, including
+within `tix-cli` itself.
+
+The payoff is that **the same document object serves reads and writes.**
+Typed sections are extracted *from* it; deltas are applied *against* it;
+sections nobody has a type for ride through both untouched. Reading and
+writing stop being separate mechanisms.
+
+### Seeds, not defaults — there is no runtime merge
+
+An earlier draft had a `Defaults` struct resolved field-wise
+(`ticket.field.or(global.defaults.field)`) on every read. That mechanism
+turns out to have no members. Two things look alike and behave completely
+differently:
+
+- **Seed** — read *once* at `tix add`, written into the ticket document.
+  Changing the global value later affects only new tickets.
+- **Default** — resolved on *every* read. Changing the global value
+  retroactively changes every ticket that did not override.
+
+**Anything that shapes git state must be a seed.** A ticket's worktrees
+were created off a specific base branch with a specific name; if those
+resolved lazily, flipping a global value would make existing tickets
+disagree with topology already on disk. Config cannot retroactively
+rewrite git.
+
+Applying the filter, everything ticket-scoped is a seed — base branch,
+branch prefix, included repos. (`repositories` isn't even an override
+pair: `defaults.repositories` is *what to seed a new ticket with*,
+`ticket.repositories` is *what it has*. Different fields.)
+
+v2 confirms this. `build_branch_name(&cfg, "JIRA-1", Some(&desc))`
+produced `feature/JIRA-1-short-summary` from global `branch_prefix` + key
++ sanitized description, derived once and written into the stamp;
+changing `branch_prefix` never renamed an existing branch. v2's
+`defaults.rs` is nothing but compile-time constants for pre-filling
+prompts. **There is no runtime override layer anywhere in the shipped
+tool.**
+
+So: a `[defaults]` table in global config that `tix add` reads at
+creation, and no resolution mechanism at all. This also removes the "host
+and SDK must call the same resolver" hazard — there is no resolver.
+
+Should a genuinely lazy preference ever appear — behavioral only, where
+retroactive change is harmless — introduce the fallback then, for that
+field alone.
+
+### Plugin state vs. plugin config
+
+Two different problems, easily conflated, with different answers. v2 kept
+them apart and an earlier v3 draft merged them.
+
+- **Plugin config** — user-facing settings a human might open and edit.
+  A `[<plugin>]` table in either document: global for user settings,
+  ticket-local for per-ticket settings. Read via the section accessors,
+  written via diff-back.
+- **Plugin state** — caches, derived data, arbitrary junk of any size or
+  shape. Files in a directory. No protocol, no delta ops, no JSON→TOML
+  typing question, no size concern.
+
+Keeping them separate means diff-back only ever carries genuine settings,
+which is a far smaller surface than "all plugin persistence."
+
+**This does not make the CLI stateful.** Tix persists only user-facing
+data (config, ticket stamps) and keeps no hidden state between
+invocations. Plugin state belongs to the *plugin*; tix merely names the
+location.
+
+**Directories are SDK helpers, not contract flags.** v2 passed
+`TIX_PLUGIN_CACHE_DIR`, `TIX_PLUGIN_STATE_DIR`, and
+`TIX_PLUGIN_TICKET_STATE_DIR` as env vars. v3 passes nothing, because
+every path is derivable from what the plugin already has:
+
+- **Per-ticket state** — `<ticket_root>/.tix/plugins/<name>/`, derived
+  from `--tix-ticket`. This is the only genuinely tix-shaped location: a
+  plugin cannot locate a ticket without being told where it is.
+- **Global state / cache** — derived from the plugin's own name plus
+  standard OS directories. A plugin can call `dirs::cache_dir()` itself;
+  there is no consistency benefit to tix mediating it, so the SDK offers
+  it only as convenience.
+
+Consistency comes from every plugin calling the same helper, not from the
+host passing values. No new flags and no protocol bump.
+
+**Create lazily**, inside the helper on first use — v2 created all three
+directories on every plugin invocation, leaving empty directories behind
+for plugins that never stored anything.
+
+## Invocation contract
+
+```
+tix-<name> --tix-protocol <int> \
+           --tix-config <path> \
+           [--tix-ticket <path>] \
+           --tix-delta <path> \
+           --tix-log-level <level> \
+           --tix-output <json|toml|default> \
+           --tix-color <bool> \
+           <user args>
+```
+
+- `--tix-config` — path to the global config file. SDK parses it into the
+  global document; sections are extracted on demand (see Config model).
+- `--tix-ticket` — path to the **ticket directory** (parent of `.tix`).
+  SDK parses `.tix/ticket.toml` into the ticket document. **Present only
+  when inside a ticket** — so the ticket document is an `Option`, and the
+  optionality is load-bearing (`tix add` creates a ticket, so it runs
+  without one). SDK provides a helper for the common "this plugin requires
+  ticket context" case.
+- `--tix-delta <path>` — host-created temp file where the SDK's write
+  helper serializes any config delta; the host reads it after the plugin
+  exits. **The delta cannot ride stdout**: plugins are ordinary
+  user-facing commands, so stdout/stderr are inherited untouched — live
+  output, prompts, colors. This is the one place a temp file is genuinely
+  needed, because stdout is taken. No file written means no changes.
+- `--tix-repo <alias>` / `--tix-repo-dir <path>` — **which repo worktree
+  the cwd is inside**, when it is inside one. v2 computed this
+  (`detect_current_repo`, longest-prefix match of cwd against
+  `ticket_root/<alias>`) and handed plugins `current_repo_alias` +
+  `current_repo_path`. Without it every plugin re-derives the same match
+  badly. Both are `Option` — cwd may be in the ticket root but not in any
+  repo.
+
+Real paths, not temp files — a deliberate reversal of v2, which wrote a
+resolved JSON snapshot to a temp file and passed `TIX_CONTEXT_PATH`. That
+suited v2 because plugins were Python-only (invoked via `uv run`) and the
+snapshot was read-only by convention. v3's plugins are language-agnostic
+subprocesses that can write back, so real paths are the better fit. With
+two disjoint documents and no merge to
+speak of, staging resolved copies buys nothing. Plugins can be hand-run
+against arbitrary paths, which is good for debugging.
+
+The whole `--tix-*` prefix is reserved for the host. The SDK strips those
+and passes user args through untouched.
+
+### Forwarded flags
+
+The host resolves its own globals *before* forwarding — it sends settled
+values, never raw flags:
+
+- **`--tix-log-level`** — the resolved level. `resolve_log_level()`
+  (`tix-cli/src/tix/mod.rs:38`) already collapses `-v`/`-q`/`--log-level`
+  and errors on conflict; plugins must not reimplement that precedence.
+- **`--tix-output`** — otherwise `tix foo --json | jq` breaks the moment a
+  plugin is involved. **Prerequisite:** `OutputType`
+  (`tix-cli/src/tix/utils.rs:16`) is currently per-subcommand and must be
+  hoisted to a global on `TixParser`.
+- **`--tix-color`** — resolved from TTY detection plus `NO_COLOR`. The
+  plugin's stdout may be piped when the host's is not; without this,
+  plugins spray ANSI into files.
+
+**`external_subcommand` caveat.** `Commands::External(Vec<String>)`
+captures everything after the plugin name *raw* — `tix foo --verbose` puts
+`--verbose` in the Vec and leaves `TixParser.verbose` false. So the host
+must pre-scan the forwarded args for its own globals before handing off.
+That pre-scan and the SDK's arg parsing are the same code, which is the
+dogfooding argument with teeth.
+
+Repo/cwd context beyond the ticket dir: deferred.
+
+### Recursive invocation
+
+A plugin may shell out to `tix` — allowed, with three hazards each closed
+by one rule:
+
+- **Lost updates.** A nested invocation (or a second terminal) may write
+  config while the outer plugin runs; the outer host must not clobber it
+  at delta-apply time. Closed by the fresh-parse-at-apply rule (see
+  Config writes) — needed regardless of recursion.
+- **Fork bombs.** `tix-foo` shelling `tix foo` recurses forever and
+  freezes the machine — the one failure that damages more than tix. The
+  host sets and increments a `TIX_DEPTH` env var and hard-fails past a
+  small cap (~10). Not policing plugins; this is the "resilient to
+  breakage" half of the philosophy.
+- **Context skew.** The nested host re-discovers from cwd, and the plugin
+  may have chdir'd — so nested `tix` can silently resolve a *different
+  ticket*. Correct (cwd is the interface) but a footgun for authors who
+  mean "same ticket." The SDK provides a spawn helper that builds a
+  `Command` pre-pinned with `--ticket-dir <current ticket>`, making the
+  supported path skew-proof by construction.
+
+### Name resolution
+
+**Builtins always win.** `tix add` runs the builtin even if a `tix-add`
+binary is on `PATH` — a stated rule (matching git), not an accident of
+clap's `external_subcommand` ordering.
+
+**Plugins are top-level commands only.** A plugin cannot extend an
+existing subcommand tree — no plugin-provided `tix config <foo>` or
+`tix ticket <bar>`. Explicitly unsupported for now; the namespace a
+plugin gets is exactly `tix <name>`.
+
+### Protocol version
+
+`--tix-protocol <int>`, monotonic, starts at 1, independent of crate
+versions. Plugins are separately compiled and will meet hosts they were
+not built against.
+
+- SDK compares against the value it was compiled with; mismatch produces
+  "built for protocol N, host speaks M — rebuild," not a parse failure.
+- **The SDK ignores unknown `--tix-*` flags.** This makes additive changes
+  safe by construction, so they need no signaling. A plugin wanting to
+  *use* something new checks whether the flag arrived — capability
+  detection for free.
+- Bump **only** on removal, rename, or semantic change to an existing flag
+  or document. Never for additions. The number should stay nearly static.
+- Give protocol mismatch a dedicated exit code so the host reports a
+  versioning problem rather than a generic plugin crash.
+- Maintain a version → change table beside the SDK. The integer is a key
+  into that document; that is what makes it legible rather than arbitrary.
+
+Rejected: protocol semver (the minor duplicates flag-presence checking),
+a feature list (restates the flags, and still cannot express a semantic
+change to an existing flag), date-based versions (fine in principle —
+Stripe and the Anthropic API do it — but overkill for a set that will
+have ~3 members ever).
+
+## Ticket discovery
+
+Walk up from cwd. A **`tix-cli` responsibility**, promoted to
+`tix-sdk` so plugins resolve tickets identically to the canonical
+frontend. Explicitly *not* an engine concern: `tix-engine` takes resolved
+paths and has no opinion on where a frontend chooses to put things.
+
+- **Match predicate is `.tix/ticket.toml`, not `.tix/`.** A project binds
+  several tickets and lives *above* them with its own `.tix/`, so testing
+  for the bare directory would halt the walk at a project and report it as
+  a ticket. Testing for the file means one upward pass collects both:
+  nearest `ticket.toml` is the ticket, nearest `project.toml` above it is
+  the project. Projects (3.1/3.2) then change what the walk *reads*, not
+  how it works.
+- **Logical paths** — walk `$PWD` as the shell reports it; do not
+  canonicalize. Matches git and matches what the user sees in their
+  prompt. Ticket dirs contain worktrees and people symlink into them, so
+  logical vs. physical resolve different tickets from the same `cd` — host
+  and SDK must agree.
+- **Ceiling: filesystem root**, stopping early at a device boundary
+  (git's `GIT_DISCOVERY_ACROSS_FILESYSTEM` default). ~1 stat per level, so
+  cost is negligible. Accidental capture by a stray `.tix` is a much
+  weaker risk than for git — `.git` is everywhere, `.tix` exists only
+  where the user put it.
+- **Nearest ancestor wins.**
+- Bounding the walk by `tickets_root` from global config was considered
+  and rejected: it couples discovery to config state, so a moved or
+  symlinked ticket fails with no visible cause.
+- Cheap safety net: if the resolved ticket dir is not under
+  `tickets_root`, log at debug and proceed. Visible under `-v`, never in
+  the way.
+
+The predicate and the walk are **already shipped behavior**: v2's
+`find_ticket_root_from_cwd()` walks up from cwd testing
+`.tix/info.toml` — the file, not the directory — to filesystem root. The
+device-boundary stop and the `tickets_root` debug check are additions, not
+changes.
+
+### Overrides
+
+Two forms, both kept (v2 had the by-name form):
+
+`--ticket <id>` — resolve by name against `tickets_directory` from global
+config, exactly as v2's `locate_ticket_root(Some(id), &config)` did
+(`config.tickets_directory.join(id)`). Skips the walk.
+
+`--ticket-dir <path>` — explicit path override, asserts *this is the
+ticket root*, skips the walk, leaves cwd alone. Erroring on a path that is
+not actually a ticket root is correct, since it is an assertion rather
+than a starting point.
+
+**Not aliased to `-C`.** `-C` conventionally means chdir-before-running
+(git; unstable cargo), where the effect on discovery is incidental. The
+two differ observably:
+
+- `tix -C ../other foo bar.txt` — `bar.txt` resolves relative to
+  `../other`, and spawned subprocesses inherit that cwd.
+- `tix --ticket-dir ../other foo bar.txt` — `bar.txt` resolves where you
+  are standing; only ticket selection changed.
+
+They also differ on near-misses: `-C some/ticket/subdir` still finds the
+ticket (it is a starting point), while `--ticket-dir some/ticket/subdir`
+should error. Aliasing forces picking one behavior and being wrong about
+the other half the time.
+
+`-C` may be added separately as its own orthogonal flag — chdir first,
+before discovery and before resolving relative path args. Composes with
+`--ticket-dir` without a conflict rule: `-C` moves you, `--ticket-dir`
+overrides selection.
+
+## Config writes
+
+Plugins may modify config. Safety is the user's responsibility, but the
+CLI should degrade gracefully rather than corrupt state.
+
+**Diff-back, not direct writes.** The plugin emits a delta (via the
+SDK's write helper, into the `--tix-delta` file — stdout belongs to the
+user) naming its target document and a key path; the host applies it
+after the plugin exits:
+
+```json
+{"target": "ticket", "ops": [{"set": "myplugin.branch", "value": "main"}]}
+```
+
+- The host stays the single writer — no stale in-memory config, no lost
+  updates when two plugins run in one session, no atomic-replace dance.
+- The host can validate a delta before committing it.
+- The target is unambiguous because there are exactly two documents.
+  Provenance tracking is unnecessary.
+
+**Deltas are applied against a fresh parse at apply time, never the
+host's startup snapshot.** A delta is an intent ("set `x.y` to z"), not a
+diff against a snapshot, so it merges naturally with whatever is on disk
+by then. Applying against the startup parse would silently discard any
+write that happened during the plugin's run — a nested `tix` invocation,
+or simply the user in a second terminal. Overlapping keys are
+last-writer-wins, which is predictable.
+
+Diff-back exists **only** because config has a single-writer constraint.
+It is not a general RPC channel and must not become one. Everything else a
+plugin does — worktrees, syncing, ticket resolution — it does directly
+through `tix-sdk → tix-engine` in its own process, because git operations
+carry no such constraint.
+
+### The host writes without comprehending
+
+A typed round-trip would be a **data-loss bug**: deserializing into the
+host's structs and re-serializing emits only what those structs model, so
+every `[<plugin>]` table silently vanishes, along with all comments and
+formatting.
+
+So the host never deserializes plugin tables at all. It applies the delta
+as a path traversal over the generic format-preserving document from the
+read path — "go to `myplugin.branch`, put `main` there" — with no idea
+what that key means. Untouched subtrees survive because they are never
+interpreted. `toml_edit`'s `DocumentMut` is the crate for this; it is what
+`cargo add` uses to edit `Cargo.toml` without mangling it. (Verify the
+current API at implementation time — the architectural requirement is a
+generic DOM, not a typed round-trip, whichever crate provides it.)
+
+The ownership split that makes this work:
+
+- **The plugin** owns its section's schema and has the types for it.
+- **The host** owns the document and treats every section as an opaque
+  subtree.
+
+Neither needs the other's types.
+
+**Validation falls out of it.** After applying the delta to the document,
+the host re-deserializes the sections it *does* have types for. If
+`[engine]` or `[cli]` no longer parse, `deny_unknown_fields` catches it
+and the host rejects the whole delta without writing. Plugin sections pass
+unvalidated — correct, since the host has no schema for them and the
+plugin validated its own on the way in.
+
+**Format:** TOML inbound (real files on disk; `tomllib` is stdlib from
+3.11 and `pytix` targets `abi3-py311`), JSON outbound (Python has no
+stdlib TOML *writer*, so a TOML delta would force `tomli-w` on every
+Python plugin). Asymmetric, but each direction uses what is universally
+available.
+
+### JSON→TOML value mapping
+
+Considered and rejected: a TOML-format delta ("patch in the target's own
+language", the JSON Patch argument). Technically clean but too esoteric a
+wire format; JSON stays.
+
+The typing gap is smaller than it first appears. JSON's *data model* has
+one number type, but its *text* distinguishes `1` from `1.0`, and real
+parsers preserve that (serde_json's `is_i64`/`is_f64`, Python's
+`int`/`float`). The mapping rule:
+
+- string → string, bool → bool, `1` → integer, `1.0` → float,
+  arrays/tables recurse.
+- **Datetime is the one genuinely inexpressible type**, handled by a
+  single tagged form: `{"$datetime": "2026-07-19T09:00:00Z"}`. The SDK
+  emits it automatically when the typed value is a datetime; everything
+  else goes untagged. (Likely never used — v2 stored `created_at` as a
+  plain ISO 8601 string, and nothing in tix wants a native TOML
+  datetime.)
+
+The SDK applies this rule on every supported path — Rust directly,
+Python via `pytix.host` — so only SDK-less hand-writers ever think about
+it.
+
+### Failure semantics
+
+The stance: tix supports *usage and execution* of plugins, nothing more.
+It stays out of the way on success and blames accurately on failure.
+
+- **stdout/stderr are inherited, never captured.** Plugins are ordinary
+  user-facing commands; their output, prompts, and colors reach the
+  terminal directly. (This is why the delta has its own channel.)
+- **Nonzero plugin exit propagates as tix's exit code, unmodified.** The
+  plugin's error is the plugin's to report; tix adds nothing.
+- **The delta is applied only on exit 0.** A failed plugin's
+  half-intended writes are discarded with the temp file.
+- **A malformed or unparseable delta is a `PluginImplementationError`**:
+  the delta is rejected wholesale, nothing is written, and tix reports it
+  as a bug in the plugin — not a tix failure, not a config corruption.
+  Same for a delta that breaks a host-owned section on revalidation.
+- **Reserved exit code.** Exit-code propagation and the protocol-mismatch
+  code must not collide: the mismatch code (exact value TBD; git/docker
+  reserve 125-ish for tool-level errors) is excluded from the propagated
+  range and documented as reserved by the contract.
+
+### Writes outside a plugin's own section
+
+Allowed, unsupported. A delta may target `[engine]` or `[cli]`; the host
+applies it if it revalidates, and what happens next is the user's
+business. Tix is not in the business of policing what plugins do with
+user-granted access — the state/config split already removed any *need*
+to write foreign sections, so doing so is a deliberate act, not a
+workaround.
+
+## Open questions
+
+1. **`[defaults]` seed field set** — which values `tix add` reads at
+   creation. v2's equivalents: `branch_prefix`, `github_base_url`,
+   `default_repository_owner`. (The *resolution* question is settled —
+   see Seeds, not defaults.)
+2. **v2 → v3 migration** — `.tix/info.toml` → `.tix/ticket.toml`, and the
+   flat v2 `config.toml` → sectioned v3 global config. Deferred until v3
+   reaches parity; noted so the discovery predicate isn't designed in a
+   way that forecloses reading both.
+3. ~~JSON→TOML value typing~~ — resolved: mapped by JSON text form
+   (`1` → integer, `1.0` → float), plus a single `{"$datetime": ...}`
+   tagged form. See JSON→TOML value mapping.
+4. ~~May a plugin write outside its own section?~~ — resolved: allowed,
+   unsupported. See Writes outside a plugin's own section.
+5. ~~Failure semantics~~ — resolved: output inherited, exit codes
+   propagate, delta applied only on exit 0, malformed delta is a
+   `PluginImplementationError`. See Failure semantics. Remaining detail:
+   the exact reserved exit-code value for protocol mismatch.
+6. ~~Builtin vs. plugin name collision~~ — resolved: builtins always win,
+   and plugins are top-level commands only (no extending subcommand
+   trees). See Name resolution.
+7. **Plugin discovery/enumeration** — how `tix --help` lists plugins;
+   whether plugins self-describe via a handshake (e.g. `--tix-describe`
+   returning JSON). Deferred — mechanism genuinely unclear for now.
+8. ~~Recursive invocation~~ — resolved: allowed, with fresh-parse-at-apply,
+   a `TIX_DEPTH` cap, and a pinned spawn helper. See Recursive invocation.
+9. ~~`-C`~~ — not now; possible later feature.
+
+## Sequencing
+
+The plan as originally written was inverted: it designed the delivery
+mechanism before the payload. Config resolution and the two-document model
+had to land first, and now have. Reasonable order from here:
+
+1. Section *types* in `tix-engine` — `EngineConfig`, `TicketConfig`,
+   `Defaults`. Shapes and (de)serialization only, over paths handed in.
+2. Document handling in `tix-cli`: discovery, parse, the typed section
+   accessors, `Defaults` resolution, and the ticket walk — the piece with
+   real edge cases.
+3. `tix-sdk`: promote (2) out of `tix-cli`, plus flag parsing and
+   the protocol check.
+4. Host pre-scan + `OutputType` hoist in `tix-cli`; wire `plugin::run`.
+5. Diff-back application in the host.
+6. `pytix` bindings and `pytix.host`.

--- a/design/spec.md
+++ b/design/spec.md
@@ -1,0 +1,437 @@
+# tix v3 — Crate architecture & plugin system: specification
+
+Status: **spec** — normative. Derived from the working design in
+`design/2026-07-18.md`; rationale and rejected alternatives live there and
+are not repeated here except where load-bearing. Requirement keywords
+(MUST/SHOULD/MAY) are used in the RFC 2119 sense.
+
+---
+
+## 1. Scope
+
+Specifies:
+
+- the workspace crate structure and dependency rules (§2),
+- the two-document config model and its read/write API (§3),
+- ticket discovery (§4),
+- the host ↔ plugin invocation contract, including the protocol version
+  (§5),
+- config writes via diff-back deltas (§6),
+- `pytix` packaging constraints (§7).
+
+Out of scope (deferred, tracked in §8): v2→v3 migration, the `-C` flag,
+repo/cwd context beyond `--tix-repo`/`--tix-repo-dir`.
+
+---
+
+## 2. Crate architecture
+
+### 2.1 Crates
+
+| Crate        | Role | Depends on | Key external deps |
+|--------------|------|------------|-------------------|
+| `tix-engine` | Domain operations over **already-resolved** paths. Section types `EngineConfig`, `TicketConfig`, `Defaults`. | — | `git2`, `serde` (`toml` as dev-dep only — parsing is the SDK's job; the `ParseError(toml::de::Error)` variant in `errors.rs` migrates to the SDK) |
+| `tix-sdk` (new) | The context-and-consistency layer shared by `tix-cli` and plugins: invocation-contract parsing, config discovery/parsing, typed section access, ticket discovery, delta writing, spawn helper. | `tix-engine` (re-exported) | `clap`, `dirs`, `toml_edit` (or equivalent format-preserving DOM) |
+| `tix-cli`    | The canonical frontend; binary `tix`. | `tix-sdk` **only** | `clap` |
+| `pytix`      | PyO3 bindings: `pytix.*` (engine) + `pytix.host` (SDK). | `tix-sdk`, `tix-engine` | `pyo3` |
+
+### 2.2 Dependency rules
+
+- Dependency chain is linear: `{tix-cli, pytix} → tix-sdk → tix-engine`.
+- `tix-sdk` MUST re-export `tix-engine` (tokio/axum style). `tix-cli`
+  MUST NOT declare a direct `tix-engine` dependency.
+- Non-CLI frontends MAY depend on `tix-engine` directly (bypassing the
+  SDK) when they want no tix layout policy.
+- `tix-engine` MUST NOT contain discovery, path resolution, or layout
+  policy, and MUST NOT have runtime deps on `clap`, `dirs`, or `toml` —
+  those concerns (arg parsing, config location, document parsing) are all
+  SDK-side.
+- `tix-sdk` is deliberately coupled to `tix-cli`. Surface grows by
+  promotion from `tix-cli` (demand direction CLI → SDK), never by
+  speculation about plugin needs. Promotion criterion: annoyance decides
+  *whether*; shape (resolved-path domain op vs. frontend policy) decides
+  *where*.
+
+### 2.3 Versioning
+
+- All workspace crates version in lockstep and release together.
+- Crate versions carry **no** compatibility semantics. The only
+  compatibility boundary is host ↔ plugin, governed solely by the
+  protocol integer (§5.4).
+
+---
+
+## 3. Config model
+
+### 3.1 Documents
+
+Two independent TOML documents. They are different documents, not layers
+of one schema; there is **no** document merge and **no** runtime
+default-resolution mechanism.
+
+1. **Global config** — the environment: directories, defaults, the
+   registered repository map. Located via `dirs`.
+2. **Ticket document** — `<ticket_root>/.tix/ticket.toml`: ticket
+   identity, description, contained repos, and a **branch per repo**.
+
+### 3.2 Sections
+
+Each document is a set of sections, one table per consumer:
+
+| Document | Section | Type | Owner |
+|----------|---------|------|-------|
+| global | `[engine]`   | `EngineConfig` | `tix-engine` |
+| global | `[cli]`      | `CliConfig`    | `tix-cli` |
+| global | `[defaults]` | `Defaults`     | `tix-engine` |
+| global | `[<plugin>]` | plugin's own   | that plugin |
+| ticket | `[ticket]`   | `TicketConfig` | `tix-engine` |
+| ticket | `[<plugin>]` | plugin's own   | that plugin |
+
+- There is **no top-level typed struct** for either document. The current
+  `Config { engine: Engine }` wrapper in
+  `tix-engine/src/types/config.rs` MUST be replaced: `Engine` becomes the
+  exported section type `EngineConfig`; the document level belongs to the
+  SDK's generic parsed tree.
+- Section types use `deny_unknown_fields`, which applies to that
+  section's subtree only.
+- `TicketConfig` (`tix-engine/src/types/ticket.rs`) is the `[ticket]`
+  section type, not the whole ticket document. Worktree state is keyed
+  by **worktree directory name**, not repo alias:
+  `worktrees: HashMap<name, { repo, branch }>` — the key is the
+  directory under the ticket root, the single-worktree case degenerates
+  to `name == alias`, and multiple worktrees of one repo (#85) need no
+  schema change. The current `Ticket.branch: String` single shared
+  branch is an oversight and MUST be corrected — worktrees share a
+  branch *prefix*, not a branch (v2 parity: `repo_branches` /
+  `repo_worktrees`).
+
+### 3.3 Read API (SDK)
+
+Two stages:
+
+1. **Locate and parse** — identical for every consumer, owned by the SDK.
+   Path source: discovery (§4) for the CLI, `--tix-config`/`--tix-ticket`
+   for plugins. Output: a generic, format-preserving document
+   (`toml_edit::DocumentMut` or equivalent — the requirement is a generic
+   DOM; verify the crate API at implementation time). No types involved.
+2. **Extract typed sections on demand**, by whoever owns the type:
+
+   ```rust
+   let doc = ctx.global();                              // parsed, untyped
+   let engine: EngineConfig = doc.section("engine")?;   // tix-engine's type
+   let cli:    CliConfig    = doc.section("cli")?;      // tix-cli's type
+   let mine:   MyPluginCfg  = doc.section("myplugin")?; // plugin's type
+   ```
+
+The SDK MUST offer both `section::<T>() -> Option<T>` and
+`section_or_default::<T>() -> T where T: Default` — absent and empty are
+meaningfully different for some consumers.
+
+The same document object serves reads and writes: typed sections are
+extracted from it, deltas applied against it, unknown sections ride
+through untouched.
+
+### 3.4 `[defaults]` — seeds, not defaults
+
+- Values in `[defaults]` are **seeds**: read once by `tix ticket setup` at ticket
+  creation and written into the ticket document. Later changes to global
+  values affect only new tickets.
+- There is **no runtime override/fallback resolver**. Anything that
+  shapes git state MUST be a seed (topology on disk cannot be
+  retroactively rewritten by config). Should a genuinely lazy,
+  behavioral-only preference appear later, its fallback is introduced
+  then, for that field alone.
+
+**Seed field set** (resolved: adopt v2's set for now; expand/retract as
+needed):
+
+| Field | Seeds | v2 equivalent |
+|-------|-------|---------------|
+| `branch_prefix` | branch name derivation at `tix ticket setup` (`<prefix>/<key>-<sanitized-description>`) | `branch_prefix` |
+| `github_base_url` | remote URL construction | `github_base_url` |
+| `default_repository_owner` | remote URL construction | `default_repository_owner` |
+| `repositories` | which repos a new ticket includes | — |
+
+Note `defaults.repositories` vs `ticket.repositories` are different
+fields, not an override pair: the former is what to seed with, the latter
+is what the ticket has.
+
+### 3.5 Plugin state vs. plugin config
+
+- **Plugin config** — human-editable settings. Lives as a `[<plugin>]`
+  table in the appropriate document. Read via section accessors, written
+  via diff-back (§6).
+- **Plugin state** — caches and derived data of any shape/size. Plain
+  files in a directory. Not part of any document, delta, or protocol.
+
+Locations are **SDK helpers, not contract flags** (no env vars, no new
+`--tix-*` flags):
+
+- Per-ticket state: `<ticket_root>/.tix/plugins/<name>/`, derived from
+  `--tix-ticket`.
+- Global state/cache: derived from plugin name + standard OS dirs
+  (`dirs`); offered as convenience only.
+
+Helpers MUST create directories lazily on first use (v2 pre-created them
+every invocation, littering empty dirs).
+
+---
+
+## 4. Ticket discovery
+
+Owned by `tix-cli`, promoted into `tix-sdk` so plugins resolve
+identically. Not an engine concern.
+
+**Algorithm** — walk upward from cwd:
+
+1. Walk the **logical** `$PWD` as the shell reports it; MUST NOT
+   canonicalize (symlinked ticket dirs are normal; host and SDK must
+   agree; matches git).
+2. Match predicate is the **file** `.tix/ticket.toml`, not the `.tix/`
+   directory (projects live above tickets with their own `.tix/`; one
+   pass collects nearest `ticket.toml` = ticket and nearest
+   `project.toml` above = project).
+3. Nearest ancestor wins.
+4. Ceiling: filesystem root; stop early at a device boundary (matching
+   git's `GIT_DISCOVERY_ACROSS_FILESYSTEM` default).
+5. Discovery MUST NOT be bounded by `tickets_root` from global config.
+   Safety net: if the resolved ticket is not under `tickets_root`, log at
+   debug and proceed.
+
+**Override** (skips the walk): a single flag, `--ticket <path | id>`,
+disambiguated by shape:
+
+- **Path form** — the argument contains a path separator, is absolute,
+  or is `.`/`..`: asserts *this path is the ticket root*; MUST error if
+  it is not one; leaves cwd alone.
+- **Id form** — any bare name: resolved as `tickets_directory.join(id)`
+  from the CLI config section (v2 parity); MUST error if the result is
+  not a ticket root.
+
+A bare name is always an id; a ticket directory in cwd must be written
+`./NAME`. Both forms are assertions, not starting points — near-misses
+(a subdirectory of a ticket) error rather than re-walking.
+
+Not aliased to `-C`. `-C` (chdir-before-running) MAY be added later as
+an orthogonal flag; it composes with `--ticket` with no conflict rule —
+`-C` moves you, `--ticket` overrides selection.
+
+---
+
+## 5. Invocation contract
+
+### 5.1 Plugin resolution
+
+- Plugins are external binaries `tix-<name>` discovered on `PATH`,
+  exec'd with user-facing args forwarded
+  (`Commands::External` in `tix-cli/src/tix/mod.rs:72` →
+  `plugin::run`).
+- **Builtins always win**: `tix add` runs the builtin even if `tix-add`
+  is on `PATH`.
+- Ticket subcommands exist both namespaced (`tix ticket setup`) and as
+  top-level aliases (`tix setup`) — namespaced for consistency, top-level
+  for convenience. Spec text uses the namespaced form; both count as
+  builtins for collision purposes.
+- Plugins are **top-level commands only** — `tix <name>`, nothing under
+  existing subcommand trees.
+
+### 5.2 Host-injected flags
+
+```
+tix-<name> --tix-protocol <int> \
+           --tix-config <path> \
+           [--tix-ticket <path>] \
+           --tix-delta <path> \
+           [--tix-repo <alias>] [--tix-repo-dir <path>] \
+           --tix-log-level <level> \
+           --tix-output <json|toml|default> \
+           --tix-color <bool> \
+           <user args>
+```
+
+| Flag | Presence | Meaning |
+|------|----------|---------|
+| `--tix-protocol` | always | Protocol integer (§5.4). |
+| `--tix-config` | always | Path to the global config file (the real file, not a staged copy). |
+| `--tix-ticket` | only inside a ticket | Path to the **ticket directory** (parent of `.tix`). Its absence is load-bearing (`tix ticket setup` creates the ticket, so it runs without one); the SDK exposes the ticket document as `Option` plus a "require ticket context" helper. |
+| `--tix-delta` | always | Host-created temp file for the outbound delta (§6). Stdout cannot carry it — stdout belongs to the user. No file written ⇒ no changes. |
+| `--tix-repo` / `--tix-repo-dir` | when cwd is inside a repo worktree | Alias and path of that worktree (longest-prefix match of cwd against `ticket_root/<alias>`, v2's `detect_current_repo`). Both `Option`. |
+| `--tix-log-level` | always | Resolved level — host collapses `-v`/`-q`/`--log-level` via `resolve_log_level()` (`tix-cli/src/tix/mod.rs:35`); plugins MUST NOT reimplement the precedence. |
+| `--tix-output` | always | Resolved output format, so `tix foo --json \| jq` works through plugins. |
+| `--tix-color` | always | Resolved from TTY detection + `NO_COLOR`, per-process (plugin's stdout may be piped when the host's is not). |
+
+Rules:
+
+- The host resolves its own globals **before** forwarding; it sends
+  settled values, never raw flags.
+- The entire `--tix-*` prefix is reserved for the host. The SDK strips
+  `--tix-*` flags and hands user args through untouched.
+- The SDK MUST ignore unknown `--tix-*` flags (makes additions safe with
+  no protocol bump; flag presence doubles as capability detection).
+- Paths are the real files — plugins can be hand-run against arbitrary
+  paths for debugging.
+
+### 5.3 Host pre-scan
+
+`external_subcommand` captures everything after the plugin name raw, so
+`tix foo --verbose` leaves `TixParser.verbose` false. The host MUST
+pre-scan forwarded args for its own global flags before handing off. The
+pre-scan and the SDK's flag parsing MUST be the same code.
+
+**Prerequisite:** `OutputType` (`tix-cli/src/tix/utils.rs:14`) is
+per-subcommand today and MUST be hoisted to a global on `TixParser`.
+
+### 5.4 Protocol version
+
+- `--tix-protocol <int>`: monotonic, starts at **1**, independent of
+  crate versions.
+- The SDK compares the received value against its compiled-in value; on
+  mismatch it MUST fail with "built for protocol N, host speaks M —
+  rebuild", exiting with the reserved exit code (§6.4).
+- Bump **only** for removal, rename, or semantic change of an existing
+  flag or document. Never for additions.
+- A version → change table MUST be maintained beside the SDK.
+
+### 5.5 Recursive invocation
+
+Plugins MAY shell out to `tix`. Three hazards, each closed by one rule:
+
+- **Lost updates** — closed by fresh-parse-at-apply (§6.2).
+- **Fork bombs** — the host sets/increments a `TIX_DEPTH` env var and
+  MUST hard-fail past a small cap (~10).
+- **Context skew** — nested `tix` re-discovers from cwd, which the plugin
+  may have changed. The SDK provides a spawn helper returning a `Command`
+  pre-pinned with `--ticket <current ticket path>`; the supported path is
+  skew-proof by construction.
+
+### 5.6 Help and enumeration
+
+`tix --help` appends a **Plugins** section after built-in help:
+
+- Scan `PATH` directories for executables matching `tix-*`; deduplicate
+  by name, first match on `PATH` wins (shell semantics); strip the
+  `tix-` prefix for display.
+- For each plugin, optionally exec `tix-<name> print-cli-help` for a
+  one-line description. A plugin that doesn't implement it, errors, or
+  hangs degrades to the bare name — the listing itself MUST never fail.
+- Handshake output is untrusted: strip control characters, cap at one
+  line before rendering.
+- `print-cli-help` is invoked **bare** — no `--tix-*` flags — so the
+  SDK's arg parsing MUST handle it before requiring host flags, and
+  SHOULD answer it automatically from a description the plugin registers.
+- A plugin's own `--help` is its own; tix does not touch it.
+- Zero plugins found (or empty `PATH`) simply omits the section.
+
+---
+
+## 6. Config writes (diff-back)
+
+Diff-back exists **only** because config has a single-writer constraint.
+It is not an RPC channel. Everything else a plugin does (worktrees,
+syncing, resolution) goes directly through `tix-sdk → tix-engine`
+in-process.
+
+### 6.1 Delta format
+
+JSON, written by the SDK's write helper into the `--tix-delta` file:
+
+```json
+{"target": "ticket", "ops": [{"set": "myplugin.branch", "value": "main"}]}
+```
+
+- `target` — `"global"` or `"ticket"` (exactly two documents; no
+  provenance needed).
+- `ops` — ordered list; overlapping keys are last-writer-wins.
+- Inbound config is TOML (real files; `tomllib` is stdlib ≥3.11);
+  outbound delta is JSON (Python has no stdlib TOML writer). Asymmetric
+  by design.
+
+**JSON→TOML value mapping** (applied by the SDK on every supported path;
+only SDK-less hand-writers think about it):
+
+- string → string, bool → bool, `1` → integer, `1.0` → float (JSON text
+  form, preserved by real parsers), arrays/tables recurse.
+- Datetime — the one inexpressible type — uses the single tagged form
+  `{"$datetime": "2026-07-19T09:00:00Z"}`; the SDK emits it automatically
+  for typed datetimes.
+
+### 6.2 Apply semantics (host)
+
+- The host is the **single writer**; it applies the delta after the
+  plugin exits.
+- Applied against a **fresh parse at apply time**, never the startup
+  snapshot — a delta is an intent, so it merges with whatever is on disk
+  (nested `tix`, second terminal).
+- The host applies ops as path traversals over the format-preserving
+  document ("go to `myplugin.branch`, put `main` there"). It MUST NOT
+  deserialize plugin tables — a typed round-trip is a data-loss bug
+  (drops `[<plugin>]` tables, comments, formatting). The plugin owns its
+  section's schema; the host owns the document and treats every section
+  as opaque.
+- **Validation:** after applying, the host re-deserializes the sections
+  it has types for. If a host-owned section (`[engine]`, `[cli]`,
+  `[defaults]`, `[ticket]`) no longer parses, the whole delta is rejected
+  and nothing is written. Plugin sections pass unvalidated.
+- Writes outside the plugin's own section are **allowed, unsupported**:
+  applied if revalidation passes; consequences are the user's business.
+
+### 6.3 Failure semantics
+
+- stdout/stderr are inherited, never captured.
+- A nonzero plugin exit propagates as tix's exit code, unmodified; the
+  delta is discarded (applied only on exit 0).
+- A malformed/unparseable delta, or one failing revalidation, is a
+  `PluginImplementationError`: rejected wholesale, nothing written,
+  reported as a bug in the plugin.
+
+### 6.4 Reserved exit code
+
+Exit code **125** is reserved for protocol mismatch, excluded from the
+propagated range, and documented in the contract. (The established
+tool-layer-error slot: `docker run`, `timeout(1)`, `git bisect run` skip.
+126/127 stay meaningful for exec failures; 128+n for signals.) A plugin
+exiting 125 for its own reasons will be misreported as a mismatch — a
+known, accepted collision.
+
+---
+
+## 7. `pytix`
+
+- PyO3 bindings, single wheel, `abi3-py311`. Always compiles bindings
+  for both crates — no Cargo feature gates, no pip extras (a wheel is
+  built once; extras cannot vary compiled content).
+- Namespacing: `pytix.*` = engine bindings; `pytix.host` = `tix-sdk`
+  bindings (the plugin's handle on the invoking host).
+- A Python plugin ships a `console_scripts` entry point named
+  `tix-<name>` and lands on `PATH` like any other plugin.
+- Deferred until a real Python plugin exists to shape it (last in
+  sequencing).
+
+---
+
+## 8. Deferred / open items
+
+1. **v2 → v3 migration** — `.tix/info.toml` → `.tix/ticket.toml`; flat
+   v2 `config.toml` → sectioned global config. Deferred until v3 parity.
+   Constraint on the present: the discovery predicate must not foreclose
+   reading both filenames.
+2. **`-C` flag** — possible later, orthogonal to `--ticket` (§4).
+3. **`[defaults]` set drift** — §3.4 adopts the v2 set provisionally;
+   fields may be added/removed as `tix ticket setup` takes shape.
+
+---
+
+## 9. Implementation sequence
+
+1. **Section types in `tix-engine`** — `EngineConfig` (from today's
+   `Engine`), `TicketConfig` with per-repo branches, `Defaults` (§3.4).
+   Shapes and (de)serialization only, over paths handed in.
+2. **Document handling in `tix-cli`** — locate/parse into the generic
+   DOM, typed section accessors, seed reads at `tix ticket setup`, and the ticket
+   walk (§4).
+3. **`tix-sdk`** — promote (2) out of `tix-cli`; add `--tix-*` flag
+   parsing and the protocol check; re-export `tix-engine`.
+4. **Host side** — pre-scan + `OutputType` hoist; wire `plugin::run`
+   (§5).
+5. **Diff-back application** in the host (§6).
+6. **`pytix`** bindings and `pytix.host` (§7).


### PR DESCRIPTION
Commits the two v3 design documents the milestone issues reference:

- `design/2026-07-18.md` — working design: rationale, rejected alternatives
- `design/spec.md` — normative spec (RFC 2119 keywords): crate structure, two-document config model, ticket discovery, host↔plugin invocation contract, diff-back writes

Independent of the implementation stack; mergeable any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)