### PR TITLE
feat(cli): add ticket discovery walk and --ticket override resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,6 +891,7 @@ name = "tix-cli"
 version = "3.0.0"
 dependencies = [
  "clap",
+ "tempfile",
  "tix-engine",
  "toml",
  "tracing",

--- a/tix-cli/Cargo.toml
+++ b/tix-cli/Cargo.toml
@@ -14,3 +14,6 @@ toml = "1.1.2"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 url = { version = "2.5.8", features = ["serde"] }
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/tix-cli/src/tix/discovery.rs
+++ b/tix-cli/src/tix/discovery.rs
@@ -1,0 +1,351 @@
+//! Ticket discovery: which ticket does a command operate on?
+//!
+//! Owned by `tix-cli` and written here first; promoted to `tix-sdk` (#96) so
+//! plugins resolve tickets identically to the canonical frontend. Explicitly
+//! *not* an engine concern — `tix-engine` takes resolved paths as given
+//! (`design/spec.md` §4).
+//!
+//! Two paths in:
+//!
+//! - **Discovery** ([`discover_ticket_root`]): walk upward from the logical
+//!   cwd testing for the *file* `.tix/ticket.toml`; nearest ancestor wins.
+//! - **Override** ([`resolve_override`]): a `--ticket <path | id>` argument,
+//!   disambiguated by shape ([`TicketRef`]). Both forms are assertions, not
+//!   starting points — a near-miss (e.g. a subdirectory of a ticket) errors
+//!   rather than re-walking.
+
+use crate::tix::ticket::TicketRef;
+use std::path::{Path, PathBuf};
+use tix_engine::TixError;
+use tracing::debug;
+
+/// Returns true if `path` is a ticket root: a directory containing the file
+/// `.tix/ticket.toml`.
+///
+/// The predicate is the **file**, not the bare `.tix/` directory — projects
+/// live above tickets with their own `.tix/`, so testing for the directory
+/// would halt an upward walk at a project and misreport it as a ticket
+/// (`design/spec.md` §4).
+pub fn is_ticket_root(path: &Path) -> bool {
+    path.join(".tix").join("ticket.toml").is_file()
+}
+
+/// The logical current working directory — `$PWD` as the shell reports it.
+///
+/// Ticket directories contain worktrees and people symlink into them, so
+/// logical vs. physical paths can resolve *different tickets* from the same
+/// `cd`. Discovery MUST NOT canonicalize (spec §4): we walk what the user
+/// sees in their prompt, matching git's behavior. `$PWD` is trusted only when
+/// it is absolute and still names the same directory as the process cwd;
+/// otherwise the process cwd is the fallback.
+pub fn logical_cwd() -> Result<PathBuf, TixError> {
+    let process_cwd = std::env::current_dir().map_err(TixError::IoError)?;
+    if let Some(pwd) = std::env::var_os("PWD") {
+        let pwd = PathBuf::from(pwd);
+        if pwd.is_absolute() && same_directory(&pwd, &process_cwd) {
+            return Ok(pwd);
+        }
+    }
+    Ok(process_cwd)
+}
+
+/// Walks upward from the logical cwd and returns the nearest ticket root.
+///
+/// Equivalent to [`discover_ticket_root_from`] starting at [`logical_cwd`].
+/// Returns `Ok(None)` when no ancestor is a ticket root — commands that
+/// require ticket context should turn that into a clear error; there is
+/// deliberately **no** fallback to the tickets directory.
+pub fn discover_ticket_root() -> Result<Option<PathBuf>, TixError> {
+    Ok(discover_ticket_root_from(&logical_cwd()?))
+}
+
+/// Walks upward from `start`, testing each directory for `.tix/ticket.toml`.
+///
+/// - Nearest ancestor wins.
+/// - Ceiling is the filesystem root, stopping early at a device boundary
+///   (matching git's `GIT_DISCOVERY_ACROSS_FILESYSTEM` default).
+/// - The walk is **not** bounded by the configured tickets directory — that
+///   coupling was rejected because a moved or symlinked ticket would fail
+///   with no visible cause (spec §4).
+pub fn discover_ticket_root_from(start: &Path) -> Option<PathBuf> {
+    let start_device = device_of(start);
+    let mut current = start;
+    loop {
+        if is_ticket_root(current) {
+            debug!(path = %current.display(), "ticket root found");
+            return Some(current.to_path_buf());
+        }
+        let parent = current.parent()?;
+        // Stop early at a device boundary: only when both devices are known
+        // and differ. An unreadable directory does not end the walk.
+        if let (Some(a), Some(b)) = (start_device, device_of(parent))
+            && a != b
+        {
+            debug!(path = %parent.display(), "stopping discovery at device boundary");
+            return None;
+        }
+        current = parent;
+    }
+}
+
+/// Resolves an explicit `--ticket` override, skipping the discovery walk.
+///
+/// Disambiguated by shape at parse time (see [`TicketRef`]):
+///
+/// - **Path form** (`./NAME`, `some/dir`, `/abs/path`, `.`, `..`): asserts
+///   *this path is the ticket root*. The cwd is left alone.
+/// - **Id form** (any bare name): resolved as `tickets_directory.join(id)`,
+///   v2 parity. A ticket directory in cwd must be written `./NAME` — a bare
+///   name is always an id.
+///
+/// Both forms are assertions: a path that is not a ticket root errors rather
+/// than being used as a starting point for a new walk.
+///
+/// As a safety net (not a bound), a resolved ticket outside
+/// `tickets_directory` is logged at debug and accepted.
+///
+/// # Errors
+///
+/// [`TixError::TicketNotFound`] if the asserted path is not a ticket root.
+pub fn resolve_override(ticket: &TicketRef, tickets_directory: &Path) -> Result<PathBuf, TixError> {
+    let (root, described) = match ticket {
+        TicketRef::Path(path) => (path.clone(), format!("path '{}'", path.display())),
+        TicketRef::Id(id) => (tickets_directory.join(id), format!("ticket id '{id}'")),
+    };
+
+    if !is_ticket_root(&root) {
+        return Err(TixError::TicketNotFound(format!(
+            "{described} is not a ticket root (no .tix/ticket.toml at {})",
+            root.display()
+        )));
+    }
+
+    if !root.starts_with(tickets_directory) {
+        debug!(
+            path = %root.display(),
+            tickets_directory = %tickets_directory.display(),
+            "resolved ticket lies outside the tickets directory"
+        );
+    }
+
+    Ok(root)
+}
+
+/// Resolves the ticket a command operates on: the `--ticket` override when
+/// given, the discovery walk otherwise.
+///
+/// Returns `Ok(None)` only when there is no override and the walk found
+/// nothing. Commands that require ticket context should error clearly on
+/// `None`; commands that merely prefer it (or create tickets) may proceed.
+pub fn resolve_ticket_root(
+    ticket: Option<&TicketRef>,
+    tickets_directory: &Path,
+) -> Result<Option<PathBuf>, TixError> {
+    match ticket {
+        Some(ticket_ref) => resolve_override(ticket_ref, tickets_directory).map(Some),
+        None => discover_ticket_root(),
+    }
+}
+
+/// Returns true when two paths name the same directory (same device+inode on
+/// Unix; canonical-path equality elsewhere).
+#[cfg(unix)]
+fn same_directory(a: &Path, b: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    match (std::fs::metadata(a), std::fs::metadata(b)) {
+        (Ok(ma), Ok(mb)) => ma.dev() == mb.dev() && ma.ino() == mb.ino(),
+        _ => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn same_directory(a: &Path, b: &Path) -> bool {
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(ca), Ok(cb)) => ca == cb,
+        _ => false,
+    }
+}
+
+/// The device id `path` lives on, when it can be determined.
+#[cfg(unix)]
+fn device_of(path: &Path) -> Option<u64> {
+    use std::os::unix::fs::MetadataExt;
+    std::fs::metadata(path).ok().map(|m| m.dev())
+}
+
+#[cfg(not(unix))]
+fn device_of(_path: &Path) -> Option<u64> {
+    // Windows has no cheap device-id equivalent here; the walk simply runs to
+    // the filesystem root.
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Creates `.tix/ticket.toml` under `root`, making it a ticket root.
+    fn make_ticket_root(root: &Path) {
+        std::fs::create_dir_all(root.join(".tix")).unwrap();
+        std::fs::write(
+            root.join(".tix/ticket.toml"),
+            "key = \"JIRA-1\"\ndescription = \"\"\n",
+        )
+        .unwrap();
+    }
+
+    // --- is_ticket_root ---
+
+    /// The predicate is the file `.tix/ticket.toml`, not the `.tix` directory.
+    #[test]
+    fn test_bare_tix_directory_is_not_a_ticket_root() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".tix")).unwrap();
+        assert!(!is_ticket_root(dir.path()));
+
+        std::fs::write(dir.path().join(".tix/ticket.toml"), "").unwrap();
+        assert!(is_ticket_root(dir.path()));
+    }
+
+    // --- discover_ticket_root_from ---
+
+    /// The walk finds the ticket root from the root itself and from nested
+    /// subdirectories.
+    #[test]
+    fn test_walk_finds_root_from_subdirectory() {
+        let dir = tempdir().unwrap();
+        let ticket = dir.path().join("tickets/JIRA-1");
+        make_ticket_root(&ticket);
+        let deep = ticket.join("backend/src/module");
+        std::fs::create_dir_all(&deep).unwrap();
+
+        assert_eq!(discover_ticket_root_from(&ticket), Some(ticket.clone()));
+        assert_eq!(discover_ticket_root_from(&deep), Some(ticket));
+    }
+
+    /// The nearest ancestor wins when tickets nest.
+    #[test]
+    fn test_nearest_ancestor_wins() {
+        let dir = tempdir().unwrap();
+        let outer = dir.path().join("outer");
+        let inner = outer.join("inner");
+        make_ticket_root(&outer);
+        make_ticket_root(&inner);
+        let deep = inner.join("some/dir");
+        std::fs::create_dir_all(&deep).unwrap();
+
+        assert_eq!(discover_ticket_root_from(&deep), Some(inner));
+    }
+
+    /// A walk with no ticket root above returns None rather than falling back
+    /// anywhere.
+    #[test]
+    fn test_walk_finds_nothing() {
+        let dir = tempdir().unwrap();
+        let deep = dir.path().join("a/b/c");
+        std::fs::create_dir_all(&deep).unwrap();
+        assert_eq!(discover_ticket_root_from(&deep), None);
+    }
+
+    /// A project directory (bare `.tix/`, no ticket.toml) above a ticket does
+    /// not halt the walk, and is not itself reported as a ticket.
+    #[test]
+    fn test_project_directory_does_not_capture_walk() {
+        let dir = tempdir().unwrap();
+        let project = dir.path().join("project");
+        std::fs::create_dir_all(project.join(".tix")).unwrap();
+        std::fs::write(project.join(".tix/project.toml"), "").unwrap();
+
+        let ticket = project.join("JIRA-1");
+        make_ticket_root(&ticket);
+        let inside_ticket = ticket.join("src");
+        std::fs::create_dir_all(&inside_ticket).unwrap();
+
+        // From inside the ticket: the ticket wins.
+        assert_eq!(discover_ticket_root_from(&inside_ticket), Some(ticket));
+        // From the project level (above the ticket): nothing — the project's
+        // bare .tix/ is not a ticket root.
+        assert_eq!(discover_ticket_root_from(&project), None);
+    }
+
+    // --- resolve_override ---
+
+    /// The path form asserts the given path is a ticket root and returns it.
+    #[test]
+    fn test_override_path_form_valid() {
+        let dir = tempdir().unwrap();
+        let ticket = dir.path().join("JIRA-1");
+        make_ticket_root(&ticket);
+
+        let resolved = resolve_override(&TicketRef::Path(ticket.clone()), dir.path()).unwrap();
+        assert_eq!(resolved, ticket);
+    }
+
+    /// A near-miss — a subdirectory of a ticket — errors rather than
+    /// re-walking: the override is an assertion, not a starting point.
+    #[test]
+    fn test_override_path_form_near_miss_errors() {
+        let dir = tempdir().unwrap();
+        let ticket = dir.path().join("JIRA-1");
+        make_ticket_root(&ticket);
+        let subdir = ticket.join("backend");
+        std::fs::create_dir_all(&subdir).unwrap();
+
+        assert!(matches!(
+            resolve_override(&TicketRef::Path(subdir), dir.path()),
+            Err(TixError::TicketNotFound(_))
+        ));
+    }
+
+    /// The id form resolves against the tickets directory.
+    #[test]
+    fn test_override_id_form_valid() {
+        let dir = tempdir().unwrap();
+        let ticket = dir.path().join("JIRA-1");
+        make_ticket_root(&ticket);
+
+        let resolved =
+            resolve_override(&TicketRef::Id("JIRA-1".to_string()), dir.path()).unwrap();
+        assert_eq!(resolved, ticket);
+    }
+
+    /// An id that names no ticket under the tickets directory errors.
+    #[test]
+    fn test_override_id_form_missing_errors() {
+        let dir = tempdir().unwrap();
+        assert!(matches!(
+            resolve_override(&TicketRef::Id("NOPE-404".to_string()), dir.path()),
+            Err(TixError::TicketNotFound(_))
+        ));
+    }
+
+    /// A valid ticket outside the tickets directory is accepted — the debug
+    /// log is a safety net, not a bound.
+    #[test]
+    fn test_override_outside_tickets_directory_accepted() {
+        let dir = tempdir().unwrap();
+        let elsewhere = dir.path().join("elsewhere/JIRA-1");
+        make_ticket_root(&elsewhere);
+        let tickets_directory = dir.path().join("tickets");
+        std::fs::create_dir_all(&tickets_directory).unwrap();
+
+        let resolved =
+            resolve_override(&TicketRef::Path(elsewhere.clone()), &tickets_directory).unwrap();
+        assert_eq!(resolved, elsewhere);
+    }
+
+    // --- resolve_ticket_root ---
+
+    /// With an override present, discovery is skipped entirely.
+    #[test]
+    fn test_resolve_prefers_override() {
+        let dir = tempdir().unwrap();
+        let ticket = dir.path().join("JIRA-1");
+        make_ticket_root(&ticket);
+
+        let resolved =
+            resolve_ticket_root(Some(&TicketRef::Path(ticket.clone())), dir.path()).unwrap();
+        assert_eq!(resolved, Some(ticket));
+    }
+}

--- a/tix-cli/src/tix/mod.rs
+++ b/tix-cli/src/tix/mod.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod repo;
 pub mod ticket;
 
+pub mod discovery;
 pub mod plugin;
 pub mod utils;
 

--- a/tix-cli/src/tix/ticket/mod.rs
+++ b/tix-cli/src/tix/ticket/mod.rs
@@ -11,9 +11,22 @@ use clap::{Args, Subcommand};
 use std::path::PathBuf;
 use std::str::FromStr;
 
+/// A `--ticket` argument: one flag, two forms, disambiguated by shape
+/// (`design/spec.md` §4).
+///
+/// - **Path** — the argument contains a path separator, is absolute, or is
+///   `.`/`..`. Asserts *this path is the ticket root*.
+/// - **Id** — any bare name, resolved against the configured tickets
+///   directory.
+///
+/// A bare name is always an id; a ticket directory in cwd must be written
+/// `./NAME`. See [`crate::tix::discovery::resolve_override`] for the
+/// resolution semantics.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TicketRef {
+    /// An asserted ticket-root path (`./NAME`, `some/dir`, `/abs/path`, `.`, `..`).
     Path(PathBuf),
+    /// A bare ticket id, resolved as `tickets_directory.join(id)`.
     Id(String),
 }
 impl FromStr for TicketRef {
@@ -21,10 +34,41 @@ impl FromStr for TicketRef {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let path = std::path::Path::new(s);
-        if path.is_absolute() || s.starts_with("./") || s.starts_with("../") {
+        let is_path_shape =
+            s == "." || s == ".." || path.is_absolute() || s.contains(['/', '\\']);
+        if is_path_shape {
             Ok(TicketRef::Path(path.to_path_buf()))
         } else {
             Ok(TicketRef::Id(s.to_string()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod ticket_ref_tests {
+    use super::*;
+
+    /// Absolute paths, `.`/`..`, and anything containing a separator parse as
+    /// the path form.
+    #[test]
+    fn test_path_shapes() {
+        for s in ["/abs/path", "./NAME", "../up", ".", "..", "some/dir"] {
+            assert!(
+                matches!(s.parse::<TicketRef>().unwrap(), TicketRef::Path(_)),
+                "expected path form for {s:?}"
+            );
+        }
+    }
+
+    /// A bare name is always an id — a ticket directory in cwd must be
+    /// written `./NAME`.
+    #[test]
+    fn test_bare_name_is_id() {
+        for s in ["JIRA-123", "my-ticket", "NAME"] {
+            assert!(
+                matches!(s.parse::<TicketRef>().unwrap(), TicketRef::Id(_)),
+                "expected id form for {s:?}"
+            );
         }
     }
 }

--- a/tix-engine/src/lib.rs
+++ b/tix-engine/src/lib.rs
@@ -12,6 +12,8 @@
 //!   where ticket directories are stored, and which repositories are registered.
 //! - A [`RepositoryConfig`] is a registered source repository.
 //!   Resolving one produces a [`Repository`] backed by a local git clone.
+//! - A [`Defaults`] is the `[defaults]` section of the global config: seed
+//!   values read once at ticket creation, never resolved at runtime.
 //! - A [`TicketConfig`] is the `[ticket]` section of a ticket document
 //!   (`.tix/ticket.toml`): the ticket's identity plus a map of worktree
 //!   directory name → [`WorktreeConfig`] recording each worktree's repository
@@ -29,6 +31,7 @@ mod types;
 mod utils;
 
 pub use types::config::Config;
+pub use types::defaults::Defaults;
 pub use types::errors::TixError;
 pub use types::repository::Repository;
 pub use types::repository::RepositoryConfig;

--- a/tix-engine/src/types/defaults.rs
+++ b/tix-engine/src/types/defaults.rs
@@ -1,0 +1,125 @@
+use serde::{Deserialize, Serialize};
+
+/// The `[defaults]` section of the global config — **seeds, not defaults**.
+///
+/// Values here are read **once** by `tix ticket setup` at ticket creation and
+/// written into the ticket document. Changing a global value later affects
+/// only new tickets; there is no runtime override/fallback resolver anywhere
+/// in tix. Anything that shapes git state must be a seed — topology on disk
+/// cannot be retroactively rewritten by config (see `design/spec.md` §3.4).
+///
+/// Every field is optional in the document: a partial (or absent) `[defaults]`
+/// section is normal, and [`Default`] gives the all-empty value for the
+/// `section_or_default` read path.
+///
+/// The field set adopts v2's provisionally and may expand or retract as
+/// `tix ticket setup` takes shape.
+///
+/// # Examples
+///
+/// A partial `[defaults]` section parses; unset fields stay `None`/empty:
+///
+/// ```
+/// # use tix_engine::Defaults;
+/// let defaults: Defaults = toml::from_str(
+///     r#"
+///     branch_prefix = "feature"
+///     repositories = ["backend", "frontend"]
+///     "#,
+/// )
+/// .unwrap();
+///
+/// assert_eq!(defaults.branch_prefix.as_deref(), Some("feature"));
+/// assert_eq!(defaults.repositories, vec!["backend", "frontend"]);
+/// assert!(defaults.github_base_url.is_none());
+/// assert!(defaults.default_repository_owner.is_none());
+/// ```
+///
+/// An empty document is the same as no section at all:
+///
+/// ```
+/// # use tix_engine::Defaults;
+/// let defaults: Defaults = toml::from_str("").unwrap();
+/// assert_eq!(defaults, Defaults::default());
+/// ```
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct Defaults {
+    /// Seed for branch name derivation at `tix ticket setup`:
+    /// `<prefix>/<key>-<sanitized-description>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch_prefix: Option<String>,
+    /// Seed for remote URL construction.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github_base_url: Option<String>,
+    /// Seed for remote URL construction: the owner used when a repository is
+    /// given without one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_repository_owner: Option<String>,
+    /// Which registered repositories a new ticket includes.
+    ///
+    /// This is *what to seed a new ticket with* — a different field from the
+    /// ticket document's worktree map (*what the ticket has*), not an
+    /// override pair.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub repositories: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_defaults() -> Defaults {
+        Defaults {
+            branch_prefix: Some("feature".to_string()),
+            github_base_url: Some("https://github.mycompany.com".to_string()),
+            default_repository_owner: Some("my-org".to_string()),
+            repositories: vec!["backend".to_string(), "frontend".to_string()],
+        }
+    }
+
+    /// A fully populated `[defaults]` section deserializes correctly.
+    #[test]
+    fn test_deserialize_full_section() {
+        let toml = r#"
+branch_prefix = "feature"
+github_base_url = "https://github.mycompany.com"
+default_repository_owner = "my-org"
+repositories = ["backend", "frontend"]
+"#;
+        let defaults: Defaults = toml::from_str(toml).unwrap();
+        assert_eq!(defaults, sample_defaults());
+    }
+
+    /// Serializing and deserializing preserves all data.
+    #[test]
+    fn test_round_trip() {
+        let defaults = sample_defaults();
+        let restored: Defaults = toml::from_str(&toml::to_string(&defaults).unwrap()).unwrap();
+        assert_eq!(restored, defaults);
+    }
+
+    /// Unset optional fields serialize to nothing rather than explicit nulls,
+    /// so a default value round-trips through an empty document.
+    #[test]
+    fn test_default_serializes_empty() {
+        assert_eq!(toml::to_string(&Defaults::default()).unwrap(), "");
+    }
+
+    /// An empty document parses to the all-empty `Default` value.
+    #[test]
+    fn test_empty_section() {
+        let defaults: Defaults = toml::from_str("").unwrap();
+        assert_eq!(defaults, Defaults::default());
+    }
+
+    /// Unknown fields in the `[defaults]` section are rejected.
+    #[test]
+    fn test_rejects_unknown_fields() {
+        let toml = r#"
+branch_prefix = "feature"
+base_branch = "not-a-seed-we-know"
+"#;
+        assert!(toml::from_str::<Defaults>(toml).is_err());
+    }
+}

--- a/tix-engine/src/types/errors.rs
+++ b/tix-engine/src/types/errors.rs
@@ -14,6 +14,10 @@ pub enum TixError {
     ConfigNotFound(String),
     /// The repository was not found at the given path.
     RepoNotFound(String),
+    /// The ticket directory was not found at the given path.
+    TicketNotFound(String),
+    /// A worktree recorded in the ticket document was not found on disk.
+    WorktreeNotFound(String),
     /// A freeform error message.
     Message(String),
 }
@@ -27,6 +31,8 @@ impl fmt::Display for TixError {
             TixError::SerializationError(e) => write!(f, "serialization error: {}", e),
             TixError::ConfigNotFound(s) => write!(f, "config not found: {}", s),
             TixError::RepoNotFound(s) => write!(f, "repo not found: {}", s),
+            TixError::TicketNotFound(s) => write!(f, "ticket not found: {}", s),
+            TixError::WorktreeNotFound(s) => write!(f, "worktree not found: {}", s),
             TixError::Message(s) => write!(f, "{}", s),
         }
     }
@@ -124,6 +130,8 @@ mod tests {
             TixError::ParseError(parse_err),
             TixError::ConfigNotFound("path".into()),
             TixError::RepoNotFound("path".into()),
+            TixError::TicketNotFound("path".into()),
+            TixError::WorktreeNotFound("path".into()),
             TixError::Message("something went wrong".into()),
         ];
 

--- a/tix-engine/src/types/mod.rs
+++ b/tix-engine/src/types/mod.rs
@@ -1,6 +1,9 @@
 /// Types related to Tix configuration and errors.
 pub mod config;
 
+/// The `[defaults]` section of the global config — seeds read at ticket creation.
+pub mod defaults;
+
 /// Types related to Tix errors.
 pub mod errors;
 

--- a/tix-engine/src/types/repository.rs
+++ b/tix-engine/src/types/repository.rs
@@ -1,7 +1,7 @@
-use crate::types::{errors::TixError, ticket::Ticket, worktree::Worktree};
+use crate::types::{errors::TixError, worktree::Worktree};
 use git2::{RepositoryState, WorktreeAddOptions};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::{debug, error, info, warn};
 
 /// The configuration for a repository.
@@ -150,10 +150,19 @@ impl Repository {
         }
     }
 
-    /// Creates a git worktree for the given ticket's branch at the ticket's path.
+    /// Creates a git worktree named `name` for `branch` at `path`.
+    ///
+    /// `name` is the worktree directory name under the ticket root — the key
+    /// of the worktree's entry in
+    /// [`TicketConfig::worktrees`](crate::TicketConfig::worktrees) — and
+    /// `path` is the full, already-resolved directory the worktree should
+    /// appear at. The engine takes both as given; deriving them from a ticket
+    /// is the frontend's job.
     ///
     /// Syncs the repository first (fetches and fast-forwards). Pass `force: true` to discard
-    /// local changes before syncing.
+    /// local changes before syncing. If `branch` exists locally the worktree
+    /// checks it out; otherwise git2 falls back to creating a fresh branch
+    /// named `name` from HEAD.
     ///
     /// # Errors
     ///
@@ -163,47 +172,60 @@ impl Repository {
     ///
     /// ```no_run
     /// # use tix_engine::RepositoryConfig;
-    /// # use tix_engine::Ticket;
     /// # use std::path::PathBuf;
     /// let repo = RepositoryConfig::new(
     ///     "https://github.com/owner/repo.git".to_string(),
     ///     PathBuf::from("/home/user/code/repo"),
     /// ).resolve("my-repo").unwrap();
-    /// let ticket = Ticket { key: "JIRA-123".into(), description: "Fix bug".into(), branch: "JIRA-123".into(), path: PathBuf::from("/home/user/tickets/JIRA-123"), worktrees: vec![] };
-    /// let worktree = repo.create_worktree(&ticket, false);
+    /// let worktree = repo.create_worktree(
+    ///     "my-repo",
+    ///     "feature/JIRA-123-fix-login",
+    ///     &PathBuf::from("/home/user/tickets/JIRA-123/my-repo"),
+    ///     false,
+    /// );
     /// ```
-    pub fn create_worktree(&self, ticket: &Ticket, force: bool) -> Result<Worktree, TixError> {
-        info!(alias = %self.alias, ticket = %ticket.key, branch = %ticket.branch, "creating worktree");
+    pub fn create_worktree(
+        &self,
+        name: &str,
+        branch: &str,
+        path: &Path,
+        force: bool,
+    ) -> Result<Worktree, TixError> {
+        info!(alias = %self.alias, name, branch, "creating worktree");
         self.sync(force)?;
 
-        let branch = self
-            .repo
-            .find_branch(&ticket.branch, git2::BranchType::Local)
-            .ok();
-        let reference = branch.map(|b| b.into_reference());
+        let local_branch = self.repo.find_branch(branch, git2::BranchType::Local).ok();
+        let reference = local_branch.map(|b| b.into_reference());
 
-        if let Some(parent) = ticket.path.parent() {
+        if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(TixError::IoError)?;
         }
 
         let mut options = WorktreeAddOptions::new();
         options.reference(reference.as_ref());
 
-        let worktree = self.repo.worktree(&ticket.branch, &ticket.path, Some(&options))
+        let worktree = self
+            .repo
+            .worktree(name, path, Some(&options))
             .map(|_| Worktree {
-                branch: ticket.branch.clone(),
+                name: name.to_string(),
+                branch: branch.to_string(),
                 repo_alias: self.alias.clone(),
-                path: ticket.path.clone(),
+                path: path.to_path_buf(),
             })
             .map_err(|e| {
-                error!(alias = %self.alias, ticket = %ticket.key, error = %e, "failed to create worktree");
+                error!(alias = %self.alias, name, error = %e, "failed to create worktree");
                 TixError::GitError(e)
             })?;
-        info!(alias = %self.alias, ticket = %ticket.key, path = %ticket.path.display(), "worktree created");
+        info!(alias = %self.alias, name, path = %path.display(), "worktree created");
         Ok(worktree)
     }
 
-    /// Prunes the git worktree for the given `branch` from this repository.
+    /// Prunes the git worktree registered as `name` from this repository.
+    ///
+    /// `name` is the worktree directory name — the same name the worktree was
+    /// created under via [`Self::create_worktree`], and the key of its entry
+    /// in [`TicketConfig::worktrees`](crate::TicketConfig::worktrees).
     ///
     /// Pass `force: true` to remove even if the worktree is in a dirty state. Without `force`,
     /// returns an error if the worktree fails validation (e.g. has uncommitted changes).
@@ -217,30 +239,23 @@ impl Repository {
     ///
     /// ```no_run
     /// # use tix_engine::RepositoryConfig;
-    /// # use tix_engine::Ticket;
     /// # use std::path::PathBuf;
     /// let repo = RepositoryConfig::new(
     ///     "https://github.com/owner/repo.git".to_string(),
     ///     PathBuf::from("/home/user/code/repo"),
     /// ).resolve("my-repo").unwrap();
-    /// let ticket = Ticket { key: "JIRA-123".into(), description: "Fix bug".into(), branch: "JIRA-123".into(), path: PathBuf::from("/home/user/tickets/JIRA-123"), worktrees: vec![] };
-    /// repo.remove_worktree(&ticket, "JIRA-123", false);
+    /// repo.remove_worktree("my-repo", false);
     /// ```
-    pub fn remove_worktree(
-        &self,
-        ticket: &Ticket,
-        branch: &str,
-        force: bool,
-    ) -> Result<(), TixError> {
-        info!(alias = %self.alias, ticket = %ticket.key, branch = %ticket.branch, "removing worktree");
+    pub fn remove_worktree(&self, name: &str, force: bool) -> Result<(), TixError> {
+        info!(alias = %self.alias, name, "removing worktree");
 
         let worktree = self
             .repo
-            .find_worktree(branch)
+            .find_worktree(name)
             .map_err(|_| TixError::from("worktree does not exist"))?;
 
         if !force && worktree.validate().is_err() {
-            error!(alias = %self.alias, ticket = %ticket.key, "worktree is dirty, use force to remove");
+            error!(alias = %self.alias, name, "worktree is dirty, use force to remove");
             return Err(TixError::from(
                 "worktree is not in a clean state, use force to remove",
             ));
@@ -250,10 +265,10 @@ impl Repository {
         opts.working_tree(true).valid(true);
 
         worktree.prune(Some(&mut opts)).map_err(|e| {
-            error!(alias = %self.alias, ticket = %ticket.key, error = %e, "failed to remove worktree");
+            error!(alias = %self.alias, name, error = %e, "failed to remove worktree");
             TixError::GitError(e)
         })?;
-        info!(alias = %self.alias, ticket = %ticket.key, "worktree removed");
+        info!(alias = %self.alias, name, "worktree removed");
         Ok(())
     }
 
@@ -556,12 +571,13 @@ mod tests {
         let local = test_helpers::clone_repo(&dir.path().join("remote"), &dir.path().join("local"));
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        let ticket = test_helpers::make_ticket("feature", &dir.path().join("worktrees/feature"));
-        let worktree = repo.create_worktree(&ticket, false).unwrap();
+        let path = dir.path().join("worktrees/feature");
+        let worktree = repo.create_worktree("feature", "feature", &path, false).unwrap();
 
+        assert_eq!(worktree.name, "feature");
         assert_eq!(worktree.branch, "feature");
-        assert_eq!(worktree.path, dir.path().join("worktrees/feature"));
-        assert!(dir.path().join("worktrees/feature").exists());
+        assert_eq!(worktree.path, path);
+        assert!(path.exists());
     }
 
     /// A ticket whose branch already exists locally reuses it and returns the correct `Worktree`.
@@ -578,11 +594,12 @@ mod tests {
         }
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        let ticket = test_helpers::make_ticket("feature", &dir.path().join("worktrees/feature"));
-        let worktree = repo.create_worktree(&ticket, false).unwrap();
+        let path = dir.path().join("worktrees/feature");
+        let worktree = repo.create_worktree("feature", "feature", &path, false).unwrap();
 
+        assert_eq!(worktree.name, "feature");
         assert_eq!(worktree.branch, "feature");
-        assert_eq!(worktree.path, dir.path().join("worktrees/feature"));
+        assert_eq!(worktree.path, path);
     }
 
     /// Creating a worktree with a name that already exists returns `TixError::GitError`.
@@ -594,11 +611,11 @@ mod tests {
         let local = test_helpers::clone_repo(&dir.path().join("remote"), &dir.path().join("local"));
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        let ticket = test_helpers::make_ticket("feature", &dir.path().join("worktrees/feature"));
-        repo.create_worktree(&ticket, false).unwrap();
+        let path = dir.path().join("worktrees/feature");
+        repo.create_worktree("feature", "feature", &path, false).unwrap();
 
         assert!(matches!(
-            repo.create_worktree(&ticket, false),
+            repo.create_worktree("feature", "feature", &path, false),
             Err(TixError::GitError(_))
         ));
     }
@@ -613,9 +630,8 @@ mod tests {
         test_helpers::make_mid_operation(&local);
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        let ticket = test_helpers::make_ticket("feature", &dir.path().join("worktrees/feature"));
         assert!(matches!(
-            repo.create_worktree(&ticket, false),
+            repo.create_worktree("feature", "feature", &dir.path().join("worktrees/feature"), false),
             Err(TixError::Message(_))
         ));
     }
@@ -631,10 +647,8 @@ mod tests {
         let local = test_helpers::clone_repo(&dir.path().join("remote"), &dir.path().join("local"));
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        let ticket =
-            test_helpers::make_ticket("nonexistent", &dir.path().join("worktrees/nonexistent"));
         assert!(matches!(
-            repo.remove_worktree(&ticket, "nonexistent", false),
+            repo.remove_worktree("nonexistent", false),
             Err(TixError::Message(_))
         ));
     }
@@ -649,9 +663,8 @@ mod tests {
         test_helpers::orphan_worktree(&local, "feature", &dir.path().join("worktrees/feature"));
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        let ticket = test_helpers::make_ticket("feature", &dir.path().join("worktrees/feature"));
         assert!(matches!(
-            repo.remove_worktree(&ticket, "feature", false),
+            repo.remove_worktree("feature", false),
             Err(TixError::Message(_))
         ));
     }
@@ -666,8 +679,7 @@ mod tests {
         test_helpers::orphan_worktree(&local, "feature", &dir.path().join("worktrees/feature"));
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        let ticket = test_helpers::make_ticket("feature", &dir.path().join("worktrees/feature"));
-        assert!(repo.remove_worktree(&ticket, "feature", true).is_ok());
+        assert!(repo.remove_worktree("feature", true).is_ok());
     }
 
     /// Removing a valid worktree succeeds and returns `Ok(())`.
@@ -680,8 +692,7 @@ mod tests {
         test_helpers::add_worktree(&local, "feature", &dir.path().join("worktrees/feature"));
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        let ticket = test_helpers::make_ticket("feature", &dir.path().join("worktrees/feature"));
-        assert!(repo.remove_worktree(&ticket, "feature", false).is_ok());
+        assert!(repo.remove_worktree("feature", false).is_ok());
         assert!(!dir.path().join("worktrees/feature").exists());
     }
 
@@ -859,7 +870,7 @@ mod tests {
 }
 
 #[cfg(test)]
-mod test_helpers {
+pub(crate) mod test_helpers {
     use super::*;
     use git2;
     use std::path::Path;
@@ -966,17 +977,6 @@ mod test_helpers {
 
         std::fs::remove_dir_all(path).unwrap();
         worktree
-    }
-
-    /// Constructs a minimal [`Ticket`] with the given `branch` and `path`.
-    pub fn make_ticket(branch: &str, path: &Path) -> Ticket {
-        Ticket {
-            key: branch.to_string(),
-            description: "".to_string(),
-            branch: branch.to_string(),
-            path: path.to_path_buf(),
-            worktrees: Vec::new(),
-        }
     }
 
     /// Creates `branch` on the bare remote without creating it locally,

--- a/tix-engine/src/types/ticket.rs
+++ b/tix-engine/src/types/ticket.rs
@@ -1,8 +1,9 @@
-use crate::types::repository::Repository;
+use crate::types::errors::TixError;
 use crate::types::worktree::{Worktree, WorktreeConfig};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use tracing::{debug, error};
 
 /// The `[ticket]` section of the ticket document (`.tix/ticket.toml`).
 ///
@@ -77,55 +78,273 @@ pub struct TicketConfig {
     pub worktrees: HashMap<String, WorktreeConfig>,
 }
 
-/// A work item with one or more git worktrees sharing a common branch.
-#[derive(Serialize, Debug)]
+impl TicketConfig {
+    /// Validates this config against disk and returns a live [`Ticket`].
+    ///
+    /// `path` is the ticket workspace directory (the parent of `.tix/`),
+    /// already resolved by the frontend — the engine does no discovery. Every
+    /// entry in [`Self::worktrees`] is verified: its directory must exist
+    /// under `path` and be openable as a git worktree. Untracked directories
+    /// under the ticket root are ignored — scratch space is allowed.
+    ///
+    /// `resolve()` promises validity: if you hold a [`Ticket`], its directory
+    /// and every recorded worktree existed at resolution time. Frontends
+    /// resolve per command, use the result, and discard it.
+    ///
+    /// # Errors
+    ///
+    /// - [`TixError::TicketNotFound`] if `path` does not exist or is not a
+    ///   directory
+    /// - [`TixError::WorktreeNotFound`] if a recorded worktree's directory is
+    ///   missing
+    /// - [`TixError::GitError`] if a recorded worktree's directory exists but
+    ///   cannot be opened as a git repository
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use tix_engine::TicketConfig;
+    /// # use std::path::PathBuf;
+    /// # fn main() -> Result<(), tix_engine::TixError> {
+    /// let config: TicketConfig = toml::from_str(
+    ///     r#"
+    ///     key = "JIRA-123"
+    ///     description = "Fix the login bug"
+    ///
+    ///     [worktrees.backend]
+    ///     repo = "backend"
+    ///     branch = "feature/JIRA-123-fix-login"
+    ///     "#,
+    /// )
+    /// .unwrap();
+    ///
+    /// let ticket = config.resolve(PathBuf::from("/home/user/tickets/JIRA-123"))?;
+    /// for worktree in ticket.worktrees() {
+    ///     println!("{} → {}", worktree.name, worktree.branch);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn resolve(self, path: PathBuf) -> Result<Ticket, TixError> {
+        debug!(key = %self.key, path = %path.display(), "resolving ticket");
+        if !path.is_dir() {
+            error!(key = %self.key, path = %path.display(), "ticket directory does not exist");
+            return Err(TixError::TicketNotFound(path.display().to_string()));
+        }
+
+        // Sort by name so the resulting Vec is deterministic — HashMap
+        // iteration order is not.
+        let mut entries: Vec<(&String, &WorktreeConfig)> = self.worktrees.iter().collect();
+        entries.sort_by(|a, b| a.0.cmp(b.0));
+
+        let mut worktrees = Vec::with_capacity(entries.len());
+        for (name, entry) in entries {
+            let worktree_path = path.join(name);
+            if !worktree_path.is_dir() {
+                error!(key = %self.key, worktree = %name, path = %worktree_path.display(), "recorded worktree is missing on disk");
+                return Err(TixError::WorktreeNotFound(format!(
+                    "'{}' recorded in ticket '{}' but missing at {}",
+                    name,
+                    self.key,
+                    worktree_path.display()
+                )));
+            }
+            // The directory must actually be a git worktree, not just any
+            // directory that happens to share the recorded name.
+            git2::Repository::open(&worktree_path).map_err(|e| {
+                error!(key = %self.key, worktree = %name, error = %e, "recorded worktree is not a git repository");
+                TixError::GitError(e)
+            })?;
+            worktrees.push(Worktree {
+                name: name.clone(),
+                repo_alias: entry.repo.clone(),
+                branch: entry.branch.clone(),
+                path: worktree_path,
+            });
+        }
+
+        debug!(key = %self.key, worktrees = worktrees.len(), "ticket resolved");
+        Ok(Ticket {
+            config: self,
+            path,
+            worktrees,
+        })
+    }
+}
+
+/// A live, validated ticket.
+///
+/// If you hold a `Ticket`, it is valid: the ticket directory exists and every
+/// worktree recorded in its [`TicketConfig`] was present on disk at resolution
+/// time. Construct one via [`TicketConfig::resolve`]; frontends resolve what
+/// they need per command, use it, and discard it.
+///
+/// `Ticket` is deliberately not serializable — it is a live object, not
+/// stored state. The stored form is [`TicketConfig`].
+#[derive(Debug)]
 pub struct Ticket {
-    /// An identifier for the ticket (e.g. `JIRA-123`).
-    pub key: String,
-    /// A human-readable description of the ticket.
-    pub description: String,
-    /// The branch name shared by all worktrees in this ticket.
-    pub branch: String,
+    /// The `[ticket]` section this ticket was resolved from.
+    pub config: TicketConfig,
     /// The path to the ticket workspace directory.
     pub path: PathBuf,
-    /// The [`Worktree`] associated with this ticket.
-    pub worktrees: Vec<Worktree>,
+    /// The verified live worktrees, in worktree-name order.
+    worktrees: Vec<Worktree>,
 }
 
 impl Ticket {
-    /// Creates a new `Ticket`.
-    fn new(
-        key: String,
-        description: String,
-        branch: String,
-        path: PathBuf,
-        worktrees: Vec<Worktree>,
-    ) -> Self {
-        // TODO: ensure path exists
-        // TODO: resolve branch from key and description
-        Self {
-            key,
-            branch,
-            description,
-            path,
-            worktrees,
-        }
-    }
-
-    /// Adds a worktree for `repo` to this ticket.
-    fn add(repo: Repository) -> Option<PathBuf> {
-        todo!("add repo to ticket")
-    }
-
-    /// Removes the worktree for `repo` from this ticket.
-    fn remove(repo: Repository) -> Option<PathBuf> {
-        todo!("remove from a ticket")
+    /// The verified live worktrees of this ticket, sorted by worktree name.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use tix_engine::TicketConfig;
+    /// # use std::path::PathBuf;
+    /// # fn main() -> Result<(), tix_engine::TixError> {
+    /// # let config: TicketConfig = toml::from_str(r#"
+    /// # key = "JIRA-123"
+    /// # description = "Fix the login bug"
+    /// # "#).unwrap();
+    /// let ticket = config.resolve(PathBuf::from("/home/user/tickets/JIRA-123"))?;
+    /// for worktree in ticket.worktrees() {
+    ///     println!("{}", worktree.path.display());
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn worktrees(&self) -> &[Worktree] {
+        &self.worktrees
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::repository::test_helpers;
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    /// Builds a real git repo and a worktree of it at `ticket_root/<name>` on
+    /// branch `<name>`, returning a `TicketConfig` entry-compatible pair.
+    fn setup_worktree(dir: &Path, name: &str, ticket_root: &Path) {
+        let remote_path = dir.join(format!("{name}-remote"));
+        let local_path = dir.join(format!("{name}-local"));
+        let remote = test_helpers::init_bare_repo(&remote_path);
+        test_helpers::add_commit_to_bare(&remote, "initial commit");
+        let local = test_helpers::clone_repo(&remote_path, &local_path);
+        test_helpers::add_worktree(&local, name, &ticket_root.join(name));
+    }
+
+    fn config_with(worktrees: &[(&str, &str, &str)]) -> TicketConfig {
+        TicketConfig {
+            key: "JIRA-123".to_string(),
+            description: "Fix the login bug".to_string(),
+            worktrees: worktrees
+                .iter()
+                .map(|(name, repo, branch)| {
+                    (
+                        name.to_string(),
+                        WorktreeConfig {
+                            repo: repo.to_string(),
+                            branch: branch.to_string(),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    // --- resolve ---
+
+    /// A ticket directory with every recorded worktree present resolves into a
+    /// live `Ticket` carrying verified worktrees in name order.
+    #[test]
+    fn test_resolve_valid() {
+        let dir = tempdir().unwrap();
+        let ticket_root = dir.path().join("ticket");
+        std::fs::create_dir_all(&ticket_root).unwrap();
+        setup_worktree(dir.path(), "backend", &ticket_root);
+        setup_worktree(dir.path(), "frontend", &ticket_root);
+
+        let config = config_with(&[
+            ("frontend", "frontend", "frontend"),
+            ("backend", "backend", "backend"),
+        ]);
+        let ticket = config.clone().resolve(ticket_root.clone()).unwrap();
+
+        assert_eq!(ticket.config, config);
+        assert_eq!(ticket.path, ticket_root);
+        let names: Vec<&str> = ticket.worktrees().iter().map(|w| w.name.as_str()).collect();
+        assert_eq!(names, vec!["backend", "frontend"]);
+        assert_eq!(ticket.worktrees()[0].repo_alias, "backend");
+        assert_eq!(ticket.worktrees()[0].path, ticket_root.join("backend"));
+    }
+
+    /// A missing ticket directory errors with `TicketNotFound`.
+    #[test]
+    fn test_resolve_missing_ticket_dir() {
+        let dir = tempdir().unwrap();
+        let config = config_with(&[]);
+        assert!(matches!(
+            config.resolve(dir.path().join("nonexistent")),
+            Err(TixError::TicketNotFound(_))
+        ));
+    }
+
+    /// A recorded worktree whose directory is missing errors with
+    /// `WorktreeNotFound` — resolve() promises validity.
+    #[test]
+    fn test_resolve_missing_recorded_worktree() {
+        let dir = tempdir().unwrap();
+        let ticket_root = dir.path().join("ticket");
+        std::fs::create_dir_all(&ticket_root).unwrap();
+
+        let config = config_with(&[("backend", "backend", "feature/x")]);
+        assert!(matches!(
+            config.resolve(ticket_root),
+            Err(TixError::WorktreeNotFound(_))
+        ));
+    }
+
+    /// A recorded worktree whose directory exists but is not a git repository
+    /// errors with `GitError`.
+    #[test]
+    fn test_resolve_recorded_worktree_not_git() {
+        let dir = tempdir().unwrap();
+        let ticket_root = dir.path().join("ticket");
+        std::fs::create_dir_all(ticket_root.join("backend")).unwrap();
+
+        let config = config_with(&[("backend", "backend", "feature/x")]);
+        assert!(matches!(
+            config.resolve(ticket_root),
+            Err(TixError::GitError(_))
+        ));
+    }
+
+    /// Untracked directories under the ticket root are ignored — scratch
+    /// space is allowed.
+    #[test]
+    fn test_resolve_ignores_untracked_directories() {
+        let dir = tempdir().unwrap();
+        let ticket_root = dir.path().join("ticket");
+        std::fs::create_dir_all(ticket_root.join("scratch-notes")).unwrap();
+        setup_worktree(dir.path(), "backend", &ticket_root);
+
+        let config = config_with(&[("backend", "backend", "backend")]);
+        let ticket = config.resolve(ticket_root).unwrap();
+        assert_eq!(ticket.worktrees().len(), 1);
+    }
+
+    /// A ticket with no recorded worktrees resolves to a live ticket with an
+    /// empty worktree list.
+    #[test]
+    fn test_resolve_empty_worktrees() {
+        let dir = tempdir().unwrap();
+        let ticket_root = dir.path().join("ticket");
+        std::fs::create_dir_all(&ticket_root).unwrap();
+
+        let ticket = config_with(&[]).resolve(ticket_root).unwrap();
+        assert!(ticket.worktrees().is_empty());
+    }
 
     fn sample_config() -> TicketConfig {
         let mut worktrees = HashMap::new();

--- a/tix-engine/src/types/worktree.rs
+++ b/tix-engine/src/types/worktree.rs
@@ -36,9 +36,18 @@ pub struct WorktreeConfig {
     pub branch: String,
 }
 
-/// A git worktree associated with a repository and ticket branch.
+/// A live git worktree associated with a repository and ticket branch.
+///
+/// Produced by [`TicketConfig::resolve`](crate::TicketConfig::resolve) (from
+/// recorded state verified against disk) or by
+/// [`Repository::create_worktree`](crate::Repository::create_worktree) (from a
+/// worktree it just created). Holding one means the worktree existed at the
+/// time it was produced.
 #[derive(Serialize, Debug, Clone, PartialEq)]
 pub struct Worktree {
+    /// The worktree directory name under the ticket root — the key of this
+    /// worktree's entry in [`TicketConfig::worktrees`](crate::TicketConfig::worktrees).
+    pub name: String,
     /// The alias of the repository.
     pub repo_alias: String,
     /// The path to the worktree directory.


### PR DESCRIPTION
Closes #55

Stacked on #108 (base: `armaan/defaults-97`).

New `tix/discovery.rs` implementing spec §4:

- `discover_ticket_root_from`: upward walk, predicate is the **file** `.tix/ticket.toml`, nearest ancestor wins, filesystem-root ceiling with early stop at device boundaries; not bounded by `tickets_directory`
- `logical_cwd`: `$PWD` when absolute and naming the same dir as the process cwd (dev+ino), process cwd otherwise; never canonicalizes
- `resolve_override`: path form asserts ticket-rootness (near-miss errors, no re-walk); id form is `tickets_directory.join(id)`; out-of-tree resolution logs at debug and proceeds
- `resolve_ticket_root`: override-else-walk entry point; returns `Option` so commands choose their own "requires ticket context" error
- `TicketRef::FromStr` fixed to the full shape rule: interior separators (`some/dir`) and bare `.`/`..` are now path-form (previously fell through to id)

`tickets_directory` is taken as a parameter — wiring to the CLI config section lands with the config work (#52/#83). 11 discovery tests + 2 shape tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)