### PR TITLE
feat(cli,engine)!: format-preserving document layer; Config → EngineConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -166,7 +166,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -575,7 +575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -629,7 +629,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -642,7 +642,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -723,9 +723,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -733,22 +733,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -818,6 +818,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,7 +836,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -864,7 +875,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -892,9 +903,11 @@ version = "3.0.0"
 dependencies = [
  "clap",
  "dirs",
+ "serde",
  "tempfile",
  "tix-engine",
  "toml",
+ "toml_edit",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -937,6 +950,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"
@@ -970,7 +998,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1139,6 +1167,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -1176,7 +1207,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1192,7 +1223,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1259,7 +1290,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1280,7 +1311,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1314,7 +1345,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/tix-cli/Cargo.toml
+++ b/tix-cli/Cargo.toml
@@ -10,8 +10,10 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.6.1", features = ["color", "derive"] }
 dirs = "6.0.0"
+serde = { version = "1.0.229", features = ["derive"] }
 tix-engine = { path = "../tix-engine" }
 toml = "1.1.2"
+toml_edit = { version = "0.25.13", features = ["serde"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 url = { version = "2.5.8", features = ["serde"] }

--- a/tix-cli/src/tix/config/mod.rs
+++ b/tix-cli/src/tix/config/mod.rs
@@ -6,6 +6,29 @@ pub mod show;
 // ---
 
 use clap::{Args, Subcommand};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// The `[cli]` section of the global config — `tix-cli`'s own settings.
+///
+/// Owned by the frontend, not the engine (`design/spec.md` §3.2): directory
+/// layout is frontend policy, and the engine has no `tickets_directory`.
+/// Extracted from the parsed document via the section accessors
+/// ([`crate::tix::document::TixDocument::section`]).
+///
+/// # Examples
+///
+/// ```text
+/// [cli]
+/// tickets_directory = "/home/user/tickets"
+/// ```
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct CliConfig {
+    /// Where ticket workspaces are created, and where id-form `--ticket`
+    /// arguments resolve (`tickets_directory.join(id)`).
+    pub tickets_directory: PathBuf,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, clap::ValueEnum)]
 pub enum ConfigKey {}

--- a/tix-cli/src/tix/document.rs
+++ b/tix-cli/src/tix/document.rs
@@ -1,0 +1,449 @@
+//! The generic, format-preserving config document layer — stage 1 and 2 of
+//! the read path (`design/spec.md` §3.3), plus the atomic write path (#67).
+//!
+//! Both tix documents (global config, `.tix/ticket.toml`) are sets of
+//! sections, one table per consumer. **There is no top-level typed struct**
+//! for either document: stage 1 parses into a generic `toml_edit` DOM with no
+//! types involved; stage 2 extracts typed sections on demand, by whoever owns
+//! the type ([`TixDocument::section`]). The same document object serves reads
+//! and writes — typed sections are extracted from it, edits applied against
+//! it, and unknown sections (plugin tables, comments, formatting) ride
+//! through untouched.
+//!
+//! A typed whole-document round-trip is a **data-loss bug**: deserializing
+//! into structs and re-serializing emits only what the structs model,
+//! silently dropping every `[<plugin>]` table plus all comments (spec §6.2).
+//! Every write in tix goes through this layer instead.
+//!
+//! Written in `tix-cli` first; promoted to `tix-sdk` (#96) so plugins parse
+//! documents identically.
+
+use serde::de::DeserializeOwned;
+use std::fmt;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use tix_engine::TixError;
+use tracing::debug;
+
+/// A parsed tix config document: a format-preserving TOML DOM with typed
+/// section extraction.
+///
+/// # Examples
+///
+/// ```ignore
+/// let doc = TixDocument::load(&config_path)?;
+/// let engine: Option<EngineConfig> = doc.section("engine")?;
+/// let defaults: Defaults = doc.section_or_default("defaults")?;
+/// ```
+#[derive(Debug, Clone)]
+pub struct TixDocument {
+    doc: toml_edit::DocumentMut,
+}
+
+impl TixDocument {
+    /// An empty document — the starting point when the file does not exist
+    /// yet (`tix config init`, first write to a fresh ticket).
+    pub fn empty() -> Self {
+        Self {
+            doc: toml_edit::DocumentMut::new(),
+        }
+    }
+
+    /// Parses TOML text into the format-preserving DOM. No types involved —
+    /// every section is present as an untyped subtree.
+    ///
+    /// # Errors
+    ///
+    /// [`TixError::Message`] with the parse diagnostic on invalid TOML.
+    pub fn parse(text: &str) -> Result<Self, TixError> {
+        let doc = text
+            .parse::<toml_edit::DocumentMut>()
+            .map_err(|e| TixError::Message(format!("invalid TOML: {e}")))?;
+        Ok(Self { doc })
+    }
+
+    /// Reads and parses the document at `path`, holding a shared advisory
+    /// lock for the duration of the read so a concurrent atomic write cannot
+    /// tear it.
+    ///
+    /// # Errors
+    ///
+    /// - [`TixError::IoError`] if the file cannot be read
+    /// - [`TixError::Message`] on invalid TOML
+    pub fn load(path: &Path) -> Result<Self, TixError> {
+        let _lock = SidecarLock::shared(path)?;
+        let text = std::fs::read_to_string(path).map_err(TixError::IoError)?;
+        Self::parse(&text)
+    }
+
+    /// Extracts the typed section `name`, by whoever owns the type.
+    ///
+    /// Returns `Ok(None)` when the section is absent — normal for, e.g., a
+    /// plugin's first run. "Absent" and "empty" are meaningfully different
+    /// for some consumers; use [`Self::section_or_default`] when they are
+    /// not.
+    ///
+    /// # Errors
+    ///
+    /// [`TixError::Message`] when the section exists but does not deserialize
+    /// into `T` (including `deny_unknown_fields` violations, which apply to
+    /// this section's subtree only).
+    pub fn section<T: DeserializeOwned>(&self, name: &str) -> Result<Option<T>, TixError> {
+        let Some(item) = self.doc.get(name) else {
+            return Ok(None);
+        };
+        // toml_edit deserializes whole documents, not bare items, so the
+        // section subtree is cloned into a fresh document root first.
+        let mut section_doc = toml_edit::DocumentMut::new();
+        *section_doc.as_item_mut() = item.clone();
+        let value = toml_edit::de::from_document(section_doc)
+            .map_err(|e| TixError::Message(format!("invalid [{name}] section: {e}")))?;
+        Ok(Some(value))
+    }
+
+    /// Extracts the typed section `name`, or `T::default()` when absent.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::section`]: a *present* but invalid section is an
+    /// error, never silently defaulted.
+    pub fn section_or_default<T: DeserializeOwned + Default>(
+        &self,
+        name: &str,
+    ) -> Result<T, TixError> {
+        Ok(self.section(name)?.unwrap_or_default())
+    }
+
+    /// The underlying format-preserving DOM, for reads beyond typed sections.
+    pub fn doc(&self) -> &toml_edit::DocumentMut {
+        &self.doc
+    }
+
+    /// The underlying format-preserving DOM, mutably — the write path for
+    /// targeted edits (`tix config set`, delta application). Edits here touch
+    /// only the addressed keys; everything else survives byte-identical.
+    pub fn doc_mut(&mut self) -> &mut toml_edit::DocumentMut {
+        &mut self.doc
+    }
+
+    /// Serializes and atomically replaces the file at `path`: write to a
+    /// sibling temp file, then rename into place (atomic on POSIX,
+    /// near-atomic on NTFS). Creates parent directories as needed.
+    ///
+    /// Callers doing read-modify-write cycles should use [`with_write`],
+    /// which holds an exclusive lock across the whole cycle; bare `save` is
+    /// for whole-file writes that do not depend on prior contents.
+    ///
+    /// # Errors
+    ///
+    /// [`TixError::IoError`] if the temp write or rename fails.
+    pub fn save(&self, path: &Path) -> Result<(), TixError> {
+        // Parent dirs must exist before the sidecar lock can be opened there.
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(TixError::IoError)?;
+        }
+        let _lock = SidecarLock::exclusive(path)?;
+        self.save_unlocked(path)
+    }
+
+    /// The atomic tmp-write + rename, without locking — [`with_write`] holds
+    /// its own exclusive lock across the full load → mutate → rename cycle.
+    /// Parent directories must already exist (the lock lives in the same
+    /// directory, so callers create them before locking).
+    fn save_unlocked(&self, path: &Path) -> Result<(), TixError> {
+        let tmp = sibling_tmp_path(path);
+        std::fs::write(&tmp, self.doc.to_string()).map_err(TixError::IoError)?;
+        std::fs::rename(&tmp, path).map_err(|e| {
+            // Leave no droppings on a failed rename.
+            let _ = std::fs::remove_file(&tmp);
+            TixError::IoError(e)
+        })?;
+        debug!(path = %path.display(), "document saved atomically");
+        Ok(())
+    }
+}
+
+impl fmt::Display for TixDocument {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.doc.fmt(f)
+    }
+}
+
+/// Runs a read-modify-write cycle under an exclusive advisory lock:
+/// lock → fresh parse → `mutate` → atomic save → unlock.
+///
+/// The fresh parse inside the lock is what makes concurrent writers safe:
+/// a second writer blocks on the lock, then parses the first writer's result,
+/// so concurrency degrades to last-writer-wins at key granularity rather
+/// than lost updates (#67; complements fresh-parse-at-apply, spec §6.2).
+/// A missing file starts from [`TixDocument::empty`].
+///
+/// # Errors
+///
+/// Propagates errors from locking, parsing, `mutate`, and the atomic save.
+///
+/// # Examples
+///
+/// ```ignore
+/// with_write(&config_path, |doc| {
+///     doc.doc_mut()["cli"]["tickets_directory"] = value(path_str);
+///     Ok(())
+/// })?;
+/// ```
+pub fn with_write<T>(
+    path: &Path,
+    mutate: impl FnOnce(&mut TixDocument) -> Result<T, TixError>,
+) -> Result<T, TixError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(TixError::IoError)?;
+    }
+    let _lock = SidecarLock::exclusive(path)?;
+    let mut document = if path.exists() {
+        // Fresh parse under the lock, never a caller-held snapshot.
+        let text = std::fs::read_to_string(path).map_err(TixError::IoError)?;
+        TixDocument::parse(&text)?
+    } else {
+        TixDocument::empty()
+    };
+    let result = mutate(&mut document)?;
+    document.save_unlocked(path)?;
+    Ok(result)
+}
+
+/// An advisory lock on a sidecar `<file>.lock`, released on drop.
+///
+/// The lock lives on a sidecar rather than the document itself because the
+/// atomic rename replaces the document's inode — a lock on the old inode
+/// would guard nothing once a writer renamed over it. The sidecar survives
+/// every rename, so all readers and writers contend on one stable file.
+struct SidecarLock {
+    file: File,
+}
+
+impl SidecarLock {
+    fn shared(document_path: &Path) -> Result<Self, TixError> {
+        let file = Self::open(document_path)?;
+        file.lock_shared().map_err(TixError::IoError)?;
+        Ok(Self { file })
+    }
+
+    fn exclusive(document_path: &Path) -> Result<Self, TixError> {
+        let file = Self::open(document_path)?;
+        file.lock().map_err(TixError::IoError)?;
+        Ok(Self { file })
+    }
+
+    fn open(document_path: &Path) -> Result<File, TixError> {
+        File::options()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(lock_path(document_path))
+            .map_err(TixError::IoError)
+    }
+}
+
+impl Drop for SidecarLock {
+    fn drop(&mut self) {
+        // Errors on unlock are unreportable from Drop; the OS releases the
+        // lock when the fd closes regardless.
+        let _ = self.file.unlock();
+    }
+}
+
+/// `<file>.lock`, next to the document.
+fn lock_path(path: &Path) -> PathBuf {
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(".lock");
+    path.with_file_name(name)
+}
+
+/// A process-unique sibling temp path for the atomic write.
+fn sibling_tmp_path(path: &Path) -> PathBuf {
+    let mut name = std::ffi::OsString::from(".");
+    name.push(path.file_name().unwrap_or_default());
+    name.push(format!(".tmp.{}", std::process::id()));
+    path.with_file_name(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use tempfile::tempdir;
+    use tix_engine::{Defaults, TicketConfig};
+
+    const DOCUMENT: &str = r#"# global tix config
+[engine.configured_repositories.my-repo]
+remote = "https://github.com/owner/repo.git" # the fork
+code_path = "/home/user/code/repo"
+
+[defaults]
+branch_prefix = "feature"
+
+# my plugin's settings — tix has no type for this table
+[myplugin]
+branch = "main"
+retries = 3
+"#;
+
+    // --- section extraction ---
+
+    /// A typed section deserializes from its subtree.
+    #[test]
+    fn test_section_extracts_typed() {
+        let doc = TixDocument::parse(DOCUMENT).unwrap();
+        let defaults: Option<Defaults> = doc.section("defaults").unwrap();
+        assert_eq!(defaults.unwrap().branch_prefix.as_deref(), Some("feature"));
+    }
+
+    /// An absent section is Ok(None), not an error.
+    #[test]
+    fn test_absent_section_is_none() {
+        let doc = TixDocument::parse(DOCUMENT).unwrap();
+        let ticket: Option<TicketConfig> = doc.section("ticket").unwrap();
+        assert!(ticket.is_none());
+    }
+
+    /// section_or_default distinguishes absent (default) from present-but-invalid (error).
+    #[test]
+    fn test_section_or_default() {
+        let doc = TixDocument::parse(DOCUMENT).unwrap();
+        let absent: Defaults = doc.section_or_default("nope").unwrap();
+        assert_eq!(absent, Defaults::default());
+
+        let invalid = TixDocument::parse("[defaults]\nbogus_field = 1\n").unwrap();
+        assert!(invalid.section_or_default::<Defaults>("defaults").is_err());
+    }
+
+    /// deny_unknown_fields applies to the extracted subtree only — foreign
+    /// sections never affect extraction of a typed one.
+    #[test]
+    fn test_unknown_sections_do_not_affect_extraction() {
+        let doc = TixDocument::parse(DOCUMENT).unwrap();
+        // [myplugin] has no tix type, and its presence breaks nothing.
+        assert!(doc.section::<Defaults>("defaults").is_ok());
+    }
+
+    /// A struct section round-trips through the same document object used
+    /// for edits.
+    #[derive(Deserialize, Default, PartialEq, Debug)]
+    #[serde(deny_unknown_fields)]
+    struct PluginSection {
+        branch: String,
+        retries: i64,
+    }
+
+    /// Consumers without engine types can still extract their own sections.
+    #[test]
+    fn test_plugin_shaped_section() {
+        let doc = TixDocument::parse(DOCUMENT).unwrap();
+        let mine: PluginSection = doc.section("myplugin").unwrap().unwrap();
+        assert_eq!(
+            mine,
+            PluginSection {
+                branch: "main".to_string(),
+                retries: 3
+            }
+        );
+    }
+
+    // --- format preservation ---
+
+    /// A targeted edit leaves every untouched byte identical: comments,
+    /// formatting, and the [myplugin] table survive.
+    #[test]
+    fn test_targeted_edit_preserves_everything_else() {
+        let mut doc = TixDocument::parse(DOCUMENT).unwrap();
+        doc.doc_mut()["defaults"]["branch_prefix"] = toml_edit::value("bugfix");
+        let out = doc.to_string();
+
+        assert!(out.contains("# global tix config"));
+        assert!(out.contains("# the fork"));
+        assert!(out.contains("# my plugin's settings — tix has no type for this table"));
+        assert!(out.contains("branch_prefix = \"bugfix\""));
+        assert!(out.contains("retries = 3"));
+        // Everything except the edited line is untouched.
+        assert_eq!(out.replace("bugfix", "feature"), DOCUMENT);
+    }
+
+    // --- atomic writes ---
+
+    /// save() round-trips through disk; load() reads it back.
+    #[test]
+    fn test_save_load_round_trip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nested/config.toml");
+        let doc = TixDocument::parse(DOCUMENT).unwrap();
+        doc.save(&path).unwrap();
+
+        let loaded = TixDocument::load(&path).unwrap();
+        assert_eq!(loaded.to_string(), DOCUMENT);
+    }
+
+    /// with_write starts from empty when the file is missing, and from a
+    /// fresh parse when it exists — sequential cycles compose.
+    #[test]
+    fn test_with_write_cycles() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        with_write(&path, |doc| {
+            doc.doc_mut()["cli"]["tickets_directory"] = toml_edit::value("/tickets");
+            Ok(())
+        })
+        .unwrap();
+        with_write(&path, |doc| {
+            doc.doc_mut()["defaults"]["branch_prefix"] = toml_edit::value("feature");
+            Ok(())
+        })
+        .unwrap();
+
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(text.contains("tickets_directory = \"/tickets\""));
+        assert!(text.contains("branch_prefix = \"feature\""));
+    }
+
+    /// A failing mutate closure writes nothing.
+    #[test]
+    fn test_with_write_failure_writes_nothing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, DOCUMENT).unwrap();
+
+        let result: Result<(), TixError> =
+            with_write(&path, |_doc| Err(TixError::Message("nope".to_string())));
+        assert!(result.is_err());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), DOCUMENT);
+    }
+
+    /// Concurrent read-modify-write cycles on one file lose no keys: the
+    /// exclusive lock serializes the cycles (#67's done-when).
+    #[test]
+    fn test_concurrent_with_write_loses_nothing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let handles: Vec<_> = (0..8)
+            .map(|i| {
+                let path = path.clone();
+                std::thread::spawn(move || {
+                    with_write(&path, |doc| {
+                        doc.doc_mut()["section"][format!("key{i}")] =
+                            toml_edit::value(i as i64);
+                        Ok(())
+                    })
+                    .unwrap();
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let text = std::fs::read_to_string(&path).unwrap();
+        for i in 0..8 {
+            assert!(text.contains(&format!("key{i} = {i}")), "missing key{i} in:\n{text}");
+        }
+    }
+}

--- a/tix-cli/src/tix/mod.rs
+++ b/tix-cli/src/tix/mod.rs
@@ -5,6 +5,7 @@ pub mod ticket;
 
 pub mod context;
 pub mod discovery;
+pub mod document;
 pub mod plugin;
 pub mod utils;
 

--- a/tix-engine/src/lib.rs
+++ b/tix-engine/src/lib.rs
@@ -8,8 +8,10 @@
 //!
 //! # Domain model
 //!
-//! - A [`Config`] describes the user's environment: where code lives,
-//!   where ticket directories are stored, and which repositories are registered.
+//! - An [`EngineConfig`] is the `[engine]` section of the global config:
+//!   the repositories registered by the user. There is no whole-document
+//!   type — documents are parsed generically by the frontend/SDK, and typed
+//!   sections are extracted on demand.
 //! - A [`RepositoryConfig`] is a registered source repository.
 //!   Resolving one produces a [`Repository`] backed by a local git clone.
 //! - A [`Defaults`] is the `[defaults]` section of the global config: seed
@@ -30,7 +32,7 @@ mod types;
 /// Shared utilities for the Tix engine.
 mod utils;
 
-pub use types::config::Config;
+pub use types::config::EngineConfig;
 pub use types::defaults::Defaults;
 pub use types::errors::TixError;
 pub use types::repository::Repository;

--- a/tix-engine/src/types/config.rs
+++ b/tix-engine/src/types/config.rs
@@ -2,52 +2,44 @@ use crate::types::repository::RepositoryConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-/// Tix Engine's configuration.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct Config {
-    engine: Engine,
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+/// The `[engine]` section of the global config.
+///
+/// This is a *section* type, not the whole document — there is deliberately
+/// no top-level typed struct for the global config (`design/spec.md` §3.2).
+/// The document level belongs to the frontend/SDK's generic parsed tree,
+/// which extracts sections on demand; a whole-document struct here would
+/// drag frontend types (`[cli]`) and plugin tables into the engine and break
+/// the layering.
+///
+/// Like every section type, the engine has no opinion on where the document
+/// lives — the frontend/SDK resolves the path and owns all IO.
+///
+/// # Examples
+///
+/// Round-tripping the `[engine]` section:
+///
+/// ```
+/// # use tix_engine::EngineConfig;
+/// let engine: EngineConfig = toml::from_str(
+///     r#"
+///     [configured_repositories.my-repo]
+///     remote = "https://github.com/owner/repo.git"
+///     code_path = "/home/user/code/repo"
+///     "#,
+/// )
+/// .unwrap();
+///
+/// assert!(engine.configured_repositories.contains_key("my-repo"));
+///
+/// let restored: EngineConfig = toml::from_str(&toml::to_string(&engine).unwrap()).unwrap();
+/// assert_eq!(restored, engine);
+/// ```
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 #[serde(deny_unknown_fields)]
-struct Engine {
-    /// Source Repositories configured by the user.
+pub struct EngineConfig {
+    /// Source repositories registered by the user, keyed by alias.
+    #[serde(default)]
     pub configured_repositories: HashMap<String, RepositoryConfig>,
-}
-
-impl Config {
-    /// Creates a new `Config` with the given repositories.
-    ///
-    /// # Example
-    /// ```
-    /// # use tix_engine::Config;
-    /// # use std::collections::HashMap;
-    /// let config = Config::new(HashMap::new());
-    /// ```
-    pub fn new(configured_repositories: HashMap<String, RepositoryConfig>) -> Self {
-        Self {
-            engine: Engine::new(configured_repositories),
-        }
-    }
-
-    /// Creates a `Config` with all fields set to empty/default values.
-    ///
-    /// # Example
-    /// ```
-    /// # use tix_engine::Config;
-    /// let config = Config::empty();
-    /// ```
-    pub fn empty() -> Self {
-        Self {
-            engine: Engine::new(HashMap::new()),
-        }
-    }
-}
-
-impl Engine {
-    fn new(configured_repositories: HashMap<String, RepositoryConfig>) -> Self {
-        Self { configured_repositories }
-    }
 }
 
 #[cfg(test)]
@@ -55,7 +47,7 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    fn sample_config() -> Config {
+    fn sample_config() -> EngineConfig {
         let mut repos = HashMap::new();
         repos.insert(
             "my-repo".to_string(),
@@ -64,53 +56,45 @@ mod tests {
                 PathBuf::from("/home/user/code/repo"),
             ),
         );
-        Config::new(repos)
+        EngineConfig {
+            configured_repositories: repos,
+        }
     }
 
-    /// A TOML document with an `[engine]` section deserializes correctly.
+    /// The `[engine]` section subtree deserializes correctly.
     #[test]
-    fn test_deserialize_engine_section() {
+    fn test_deserialize_section() {
         let toml = r#"
-[engine.configured_repositories.my-repo]
+[configured_repositories.my-repo]
 remote = "https://github.com/owner/repo.git"
 code_path = "/home/user/code/repo"
 "#;
-        let config: Config = toml::from_str(toml).unwrap();
+        let config: EngineConfig = toml::from_str(toml).unwrap();
         assert_eq!(config, sample_config());
     }
 
-    /// Extra unknown top-level tables are silently ignored.
+    /// An empty section parses to the default (no repositories).
     #[test]
-    fn test_deserialize_ignores_unknown_top_level_tables() {
-        let toml = r#"
-[engine.configured_repositories.my-repo]
-remote = "https://github.com/owner/repo.git"
-code_path = "/home/user/code/repo"
-
-[cli]
-color = true
-"#;
-        let config: Config = toml::from_str(toml).unwrap();
-        assert_eq!(config, sample_config());
+    fn test_empty_section() {
+        let config: EngineConfig = toml::from_str("").unwrap();
+        assert_eq!(config, EngineConfig::default());
     }
 
-    /// Unknown fields under `[engine]` are rejected.
+    /// Unknown fields in the section are rejected — `deny_unknown_fields`
+    /// applies to this subtree only.
     #[test]
-    fn test_deserialize_rejects_unknown_engine_fields() {
+    fn test_rejects_unknown_fields() {
         let toml = r#"
-[engine]
 unknown_field = "bad"
 "#;
-        assert!(toml::from_str::<Config>(toml).is_err());
+        assert!(toml::from_str::<EngineConfig>(toml).is_err());
     }
 
-    /// Serializing and deserializing a Config preserves all data under `[engine]` nesting.
+    /// Serializing and deserializing preserves all data.
     #[test]
     fn test_round_trip() {
         let config = sample_config();
-        let toml = toml::to_string(&config).unwrap();
-        assert!(toml.contains("[engine."));
-        let restored: Config = toml::from_str(&toml).unwrap();
+        let restored: EngineConfig = toml::from_str(&toml::to_string(&config).unwrap()).unwrap();
         assert_eq!(config, restored);
     }
 }


### PR DESCRIPTION
Implements the spec §3.3 document layer in `tix-cli` (promotion to the SDK: #96) and the atomic write path — part of #67 (the "done when" concurrency test is included; #67 itself closes when this is promoted SDK-side).

Stacked on #111 (base: `armaan/config-path-52`).

- `tix/document.rs`: `TixDocument` over `toml_edit::DocumentMut` — `parse`/`load`, `section::<T>()` / `section_or_default::<T>()`, `doc_mut()` for targeted edits, `Display`
- Atomic saves: sibling tmp + `rename`; advisory locks (std file locking, no new dep) on a sidecar `<file>.lock` so the lock survives the inode swap; `with_write()` = lock → **fresh parse** → mutate → atomic save
- Format-preservation proven by test: a targeted edit leaves the rest of the file byte-identical, `[myplugin]` table and comments included; 8-thread concurrent `with_write` loses no keys
- **Breaking (engine):** `Config`/`Engine` wrapper replaced by the exported section type `EngineConfig` (`deny_unknown_fields`, `configured_repositories` defaulted so an empty `[engine]` parses) per spec §3.2
- `CliConfig { tickets_directory }` added frontend-side ([cli] is CLI-owned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)