### PR TITLE
feat(cli): implement tix config get/set/show/init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -904,6 +904,7 @@ dependencies = [
  "clap",
  "dirs",
  "serde",
+ "serde_json",
  "tempfile",
  "tix-engine",
  "toml",

--- a/tix-cli/Cargo.toml
+++ b/tix-cli/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 clap = { version = "4.6.1", features = ["color", "derive"] }
 dirs = "6.0.0"
 serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
 tix-engine = { path = "../tix-engine" }
 toml = "1.1.2"
 toml_edit = { version = "0.25.13", features = ["serde"] }

--- a/tix-cli/src/main.rs
+++ b/tix-cli/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
         fail(e);
     }
 
-    match parsed.command {
+    let result = match parsed.command {
         Commands::Cli(args) => match args.command {
             cli::CliCommands::Completions(args) => cli::completions::run(&context, args),
             cli::CliCommands::Update(args) => cli::update::run(&context, args),
@@ -65,5 +65,9 @@ fn main() {
         Commands::Setup(args) => ticket::setup::run(&context, args),
 
         Commands::External(args) => plugin::run(&context, args),
+    };
+
+    if let Err(e) = result {
+        fail(e);
     }
 }

--- a/tix-cli/src/tix/cli/completions.rs
+++ b/tix-cli/src/tix/cli/completions.rs
@@ -1,4 +1,5 @@
 use crate::tix::context::Context;
+use tix_engine::TixError;
 use clap;
 
 #[derive(Debug, Clone, PartialEq, Eq, clap::ValueEnum)]
@@ -13,6 +14,7 @@ pub struct Args {
     pub shell: Shells,
 }
 
-pub fn run(_context: &Context, args: Args) {
+pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
     println!("{:#?}", args);
+    Ok(())
 }

--- a/tix-cli/src/tix/cli/update.rs
+++ b/tix-cli/src/tix/cli/update.rs
@@ -1,9 +1,11 @@
 use crate::tix::context::Context;
+use tix_engine::TixError;
 use clap;
 
 #[derive(clap::Args, Debug)]
 pub struct Args {}
 
-pub fn run(_context: &Context, args: Args) {
+pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
     println!("{:#?}", args);
+    Ok(())
 }

--- a/tix-cli/src/tix/config/get.rs
+++ b/tix-cli/src/tix/config/get.rs
@@ -1,17 +1,86 @@
-use crate::tix::context::Context;
+//! `tix config get` — read value(s) from the `[cli]` section.
+
 use crate::tix::config::ConfigKey;
+use crate::tix::context::Context;
+use crate::tix::document::TixDocument;
 use crate::tix::utils::OutputType;
+use tix_engine::TixError;
 
-use clap;
-
+/// Arguments for `tix config get`.
 #[derive(clap::Args, Debug)]
 pub struct Args {
+    /// Output format
     #[arg(short, long)]
     pub output: Option<OutputType>,
 
+    /// The `[cli]` key(s) to read
+    #[arg(required = true)]
     pub key: Vec<ConfigKey>,
 }
 
-pub fn run(_context: &Context, args: Args) {
-    println!("{:#?}", args);
+/// Reads each requested key as a path into `[cli]` and prints its value.
+///
+/// A single key prints the bare value (scripting-friendly); multiple keys
+/// print `key = value` lines. Keys are validated at parse time by the
+/// [`ConfigKey`] value enum; a key that is valid but unset in the document
+/// errors here.
+pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+    let document = TixDocument::load(&context.config_path)?;
+
+    let mut pairs = Vec::with_capacity(args.key.len());
+    for key in &args.key {
+        let item = document
+            .doc()
+            .get("cli")
+            .and_then(|cli| cli.get(key.toml_key()))
+            .ok_or_else(|| {
+                TixError::Message(format!(
+                    "'{}' is not set in [cli] (config: {})",
+                    key.toml_key(),
+                    context.config_path.display()
+                ))
+            })?;
+        pairs.push((key.toml_key(), item.clone()));
+    }
+
+    match args.output.unwrap_or(OutputType::Default) {
+        OutputType::Default => {
+            if let [(_, item)] = pairs.as_slice() {
+                println!("{}", render_bare(item));
+            } else {
+                for (key, item) in &pairs {
+                    println!("{key} = {}", item.to_string().trim());
+                }
+            }
+        }
+        OutputType::Toml => {
+            for (key, item) in &pairs {
+                println!("{key} = {}", item.to_string().trim());
+            }
+        }
+        OutputType::Json => {
+            let mut object = serde_json::Map::new();
+            for (key, item) in &pairs {
+                object.insert((*key).to_string(), item_to_json(key, item)?);
+            }
+            println!("{}", serde_json::to_string_pretty(&object).unwrap());
+        }
+    }
+    Ok(())
+}
+
+/// A scalar's natural text (unquoted strings); non-scalars render as TOML.
+fn render_bare(item: &toml_edit::Item) -> String {
+    match item.as_str() {
+        Some(s) => s.to_string(),
+        None => item.to_string().trim().to_string(),
+    }
+}
+
+/// Converts one TOML item to JSON by round-tripping it through a real TOML
+/// parse — handles every value shape without a hand-written mapping.
+fn item_to_json(key: &str, item: &toml_edit::Item) -> Result<serde_json::Value, TixError> {
+    let table: toml::Table = toml::from_str(&format!("{key} = {}", item.to_string().trim()))?;
+    let value = table.get(key).cloned().unwrap_or(toml::Value::String(String::new()));
+    serde_json::to_value(value).map_err(|e| TixError::Message(format!("json conversion failed: {e}")))
 }

--- a/tix-cli/src/tix/config/init.rs
+++ b/tix-cli/src/tix/config/init.rs
@@ -1,9 +1,48 @@
+//! `tix config init` — interactive first-time config creation.
+
 use crate::tix::context::Context;
-use clap;
+use crate::tix::document::TixDocument;
+use crate::tix::utils::prompt;
+use tix_engine::TixError;
 
+/// Arguments for `tix config init`.
 #[derive(clap::Args, Debug)]
-pub struct Args {}
+pub struct Args {
+    /// Overwrite an existing config file
+    #[arg(long)]
+    pub force: bool,
+}
 
-pub fn run(_context: &Context, args: Args) {
-    println!("{:#?}", args);
+/// Creates the global config interactively.
+///
+/// Prompts for each required `[cli]` field with a pre-filled default, then
+/// writes to the resolved config path — the same resolution every command
+/// uses (`--config` > `TIX_CONFIG_PATH` > platform default), which is why
+/// this command is exempt from the config-must-exist check. Parent
+/// directories are created; an existing file is refused without `--force`.
+pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+    let path = &context.config_path;
+    if path.exists() && !args.force {
+        return Err(TixError::Message(format!(
+            "config already exists at {} — pass --force to overwrite",
+            path.display()
+        )));
+    }
+
+    let default_tickets = dirs::home_dir().map(|home| home.join("tickets"));
+    let tickets_directory = prompt(
+        "Tickets directory",
+        default_tickets.as_deref().and_then(|p| p.to_str()),
+    )?;
+
+    let mut document = TixDocument::empty();
+    // An explicit [cli] table, not the inline `cli = { … }` form index-based
+    // auto-creation would produce.
+    let mut cli = toml_edit::Table::new();
+    cli["tickets_directory"] = toml_edit::value(tickets_directory);
+    document.doc_mut()["cli"] = toml_edit::Item::Table(cli);
+    document.save(path)?;
+
+    println!("Wrote {}", path.display());
+    Ok(())
 }

--- a/tix-cli/src/tix/config/mod.rs
+++ b/tix-cli/src/tix/config/mod.rs
@@ -30,8 +30,26 @@ pub struct CliConfig {
     pub tickets_directory: PathBuf,
 }
 
+/// A `[cli]` key addressable by `tix config get`/`set`.
+///
+/// Being a value enum, unknown keys are rejected at argument-parse time with
+/// clap's own diagnostics. New `[cli]` fields grow a variant here alongside
+/// their [`CliConfig`] field.
 #[derive(Debug, Clone, PartialEq, Eq, clap::ValueEnum)]
-pub enum ConfigKey {}
+pub enum ConfigKey {
+    /// `tickets_directory` — where ticket workspaces live.
+    #[value(alias = "tickets_directory")]
+    TicketsDirectory,
+}
+
+impl ConfigKey {
+    /// The key's name in the `[cli]` table.
+    pub fn toml_key(&self) -> &'static str {
+        match self {
+            ConfigKey::TicketsDirectory => "tickets_directory",
+        }
+    }
+}
 
 #[derive(Args)]
 pub struct ConfigArgs {

--- a/tix-cli/src/tix/config/set.rs
+++ b/tix-cli/src/tix/config/set.rs
@@ -1,14 +1,59 @@
+//! `tix config set` — write one `[cli]` key through the format-preserving
+//! document layer.
+
+use crate::tix::config::{CliConfig, ConfigKey};
 use crate::tix::context::Context;
-use super::ConfigKey;
+use crate::tix::document::with_write;
+use tix_engine::TixError;
 
-use clap;
-
+/// Arguments for `tix config set`.
 #[derive(clap::Args, Debug)]
 pub struct Args {
+    /// The `[cli]` key to set
     pub key: ConfigKey,
+
+    /// The new value (parsed as a TOML value when possible, else a string)
     pub value: String,
 }
 
-pub fn run(_context: &Context, args: Args) {
-    println!("{:#?}", args);
+/// Sets `[cli].<key>` and persists atomically.
+///
+/// The edit is a targeted path traversal over the format-preserving DOM —
+/// plugin tables, comments, and formatting elsewhere in the file survive
+/// byte-identical (spec §6.2 applies to the CLI itself, not just plugin
+/// deltas). Before writing, the resulting `[cli]` section is re-deserialized
+/// into [`CliConfig`]; a value the type rejects fails the whole write, and
+/// nothing lands on disk ([`with_write`] discards on error).
+///
+/// The whole cycle runs under the exclusive advisory lock (#67), so
+/// concurrent `tix config set` invocations serialize rather than clobber.
+pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+    with_write(&context.config_path, |document| {
+        // `1` stays an integer, `true` a bool; anything that isn't valid
+        // TOML (a bare path, say) is a string.
+        let value: toml_edit::Value = args
+            .value
+            .parse()
+            .unwrap_or_else(|_| toml_edit::Value::from(args.value.as_str()));
+        // entry().or_insert with an explicit table so a missing [cli]
+        // materializes as a real section, not an inline `cli = { … }`.
+        document
+            .doc_mut()
+            .entry("cli")
+            .or_insert(toml_edit::table())[args.key.toml_key()] = toml_edit::Item::Value(value);
+
+        // Revalidate: the edited section must still parse as CliConfig
+        // (deny_unknown_fields; type-incompatible values fail here).
+        let _valid: CliConfig = document.section("cli")?.ok_or_else(|| {
+            TixError::Message("edit produced no [cli] section — this is a bug".to_string())
+        })?;
+        Ok(())
+    })?;
+    println!(
+        "{} = {} ({})",
+        args.key.toml_key(),
+        args.value,
+        context.config_path.display()
+    );
+    Ok(())
 }

--- a/tix-cli/src/tix/config/show.rs
+++ b/tix-cli/src/tix/config/show.rs
@@ -1,17 +1,34 @@
+//! `tix config show` — print the whole global config document.
+
 use crate::tix::context::Context;
+use crate::tix::document::TixDocument;
 use crate::tix::utils::OutputType;
+use tix_engine::TixError;
 
-use clap;
-
+/// Arguments for `tix config show`.
 #[derive(clap::Args, Debug)]
 pub struct Args {
+    /// Output format (default preserves the file as-is)
     #[arg(short, long)]
     pub output: Option<OutputType>,
-
-    #[arg(short, long)]
-    pub path: bool,
 }
 
-pub fn run(_context: &Context, args: Args) {
-    println!("{:#?}", args);
+/// Prints the global config document.
+///
+/// The default (and TOML) output is the parsed document rendered as-is —
+/// comments, formatting, and plugin tables preserved, straight from the
+/// format-preserving DOM. JSON output converts the document's *values*
+/// (comments cannot survive a format that has none).
+pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+    let document = TixDocument::load(&context.config_path)?;
+    match args.output.unwrap_or(OutputType::Default) {
+        OutputType::Default | OutputType::Toml => print!("{document}"),
+        OutputType::Json => {
+            let value: toml::Value = toml::from_str(&document.to_string())?;
+            let json = serde_json::to_string_pretty(&value)
+                .map_err(|e| TixError::Message(format!("json conversion failed: {e}")))?;
+            println!("{json}");
+        }
+    }
+    Ok(())
 }

--- a/tix-cli/src/tix/plugin.rs
+++ b/tix-cli/src/tix/plugin.rs
@@ -1,5 +1,7 @@
 use crate::tix::context::Context;
+use tix_engine::TixError;
 
-pub fn run(_context: &Context, args: Vec<String>) {
+pub fn run(_context: &Context, args: Vec<String>) -> Result<(), TixError> {
     println!("{:#?}", args);
+    Ok(())
 }

--- a/tix-cli/src/tix/repo/add.rs
+++ b/tix-cli/src/tix/repo/add.rs
@@ -1,4 +1,5 @@
 use crate::tix::context::Context;
+use tix_engine::TixError;
 use crate::tix::repo::{RepoAlias, RepoRef};
 
 use clap;
@@ -11,6 +12,7 @@ pub struct Args {
     pub repo: RepoRef,
 }
 
-pub fn run(_context: &Context, args: Args) {
+pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
     println!("{:#?}", args);
+    Ok(())
 }

--- a/tix-cli/src/tix/repo/clone.rs
+++ b/tix-cli/src/tix/repo/clone.rs
@@ -1,4 +1,5 @@
 use crate::tix::context::Context;
+use tix_engine::TixError;
 use crate::tix::repo::RepoAlias;
 
 use clap;
@@ -8,6 +9,7 @@ pub struct Args {
     pub repo_aliases: Vec<RepoAlias>,
 }
 
-pub fn run(_context: &Context, args: Args) {
+pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
     println!("{:#?}", args);
+    Ok(())
 }

--- a/tix-cli/src/tix/ticket/add.rs
+++ b/tix-cli/src/tix/ticket/add.rs
@@ -1,4 +1,5 @@
 use crate::tix::context::Context;
+use tix_engine::TixError;
 use super::TicketSharedArgs;
 use crate::tix::repo::RepoAlias;
 
@@ -12,6 +13,7 @@ pub struct Args {
     pub repo_aliases: Vec<RepoAlias>,
 }
 
-pub fn run(_context: &Context, args: Args) {
+pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
     println!("{:#?}", args);
+    Ok(())
 }

--- a/tix-cli/src/tix/ticket/destroy.rs
+++ b/tix-cli/src/tix/ticket/destroy.rs
@@ -1,4 +1,5 @@
 use crate::tix::context::Context;
+use tix_engine::TixError;
 use super::TicketSharedArgs;
 use clap;
 
@@ -8,6 +9,7 @@ pub struct Args {
     pub shared: TicketSharedArgs,
 }
 
-pub fn run(_context: &Context, args: Args) {
+pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
     println!("{:#?}", args);
+    Ok(())
 }

--- a/tix-cli/src/tix/ticket/info.rs
+++ b/tix-cli/src/tix/ticket/info.rs
@@ -1,4 +1,5 @@
 use crate::tix::context::Context;
+use tix_engine::TixError;
 use super::TicketSharedArgs;
 use clap;
 
@@ -8,6 +9,7 @@ pub struct Args {
     pub shared: TicketSharedArgs,
 }
 
-pub fn run(_context: &Context, args: Args) {
+pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
     println!("{:#?}", args);
+    Ok(())
 }

--- a/tix-cli/src/tix/ticket/list.rs
+++ b/tix-cli/src/tix/ticket/list.rs
@@ -1,4 +1,5 @@
 use crate::tix::context::Context;
+use tix_engine::TixError;
 use super::TicketSharedArgs;
 use clap;
 
@@ -8,6 +9,7 @@ pub struct Args {
     pub shared: TicketSharedArgs,
 }
 
-pub fn run(_context: &Context, args: Args) {
+pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
     println!("{:#?}", args);
+    Ok(())
 }

--- a/tix-cli/src/tix/ticket/remove.rs
+++ b/tix-cli/src/tix/ticket/remove.rs
@@ -1,4 +1,5 @@
 use crate::tix::context::Context;
+use tix_engine::TixError;
 use super::TicketSharedArgs;
 use crate::tix::repo::RepoAlias;
 
@@ -12,6 +13,7 @@ pub struct Args {
     pub repo_aliases: Vec<RepoAlias>,
 }
 
-pub fn run(_context: &Context, args: Args) {
+pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
     println!("{:#?}", args);
+    Ok(())
 }

--- a/tix-cli/src/tix/ticket/setup.rs
+++ b/tix-cli/src/tix/ticket/setup.rs
@@ -1,4 +1,5 @@
 use crate::tix::context::Context;
+use tix_engine::TixError;
 use crate::tix::repo::RepoAlias;
 use crate::tix::ticket::TicketRef;
 
@@ -19,6 +20,7 @@ pub struct Args {
     pub repo_aliases: Vec<RepoAlias>,
 }
 
-pub fn run(_context: &Context, args: Args) {
+pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
     println!("{:#?}", args);
+    Ok(())
 }

--- a/tix-cli/src/tix/utils.rs
+++ b/tix-cli/src/tix/utils.rs
@@ -16,3 +16,33 @@ pub enum OutputType {
     Toml,
     Default,
 }
+
+/// Prompts on stderr and reads one line from stdin; an empty answer takes
+/// `default` when one is offered.
+///
+/// The prompt goes to stderr so interactive commands stay pipeable — stdout
+/// carries only results.
+pub fn prompt(label: &str, default: Option<&str>) -> Result<String, tix_engine::TixError> {
+    use std::io::{BufRead, Write};
+
+    match default {
+        Some(default) => eprint!("{label} [{default}]: "),
+        None => eprint!("{label}: "),
+    }
+    std::io::stderr().flush().map_err(tix_engine::TixError::IoError)?;
+
+    let mut answer = String::new();
+    std::io::stdin()
+        .lock()
+        .read_line(&mut answer)
+        .map_err(tix_engine::TixError::IoError)?;
+    let answer = answer.trim();
+
+    match (answer.is_empty(), default) {
+        (false, _) => Ok(answer.to_string()),
+        (true, Some(default)) => Ok(default.to_string()),
+        (true, None) => Err(tix_engine::TixError::Message(format!(
+            "{label} is required"
+        ))),
+    }
+}


### PR DESCRIPTION
Closes #83

Stacked on #112 (base: `armaan/document-layer`).

- **show**: document as-is for default/toml (comments preserved); `--output json` converts values
- **get**: DOM-path reads from `[cli]`; bare value for a single key, `key = value` lines for several; unknown keys rejected at parse time (`ConfigKey` value enum, with `tickets_directory` snake_case alias)
- **set**: targeted DOM edit under the exclusive lock → `CliConfig` revalidation (`deny_unknown_fields` + type errors both reject) → atomic write; failed revalidation writes nothing
- **init**: prompts on stderr with `~/tickets` prefill; writes an explicit `[cli]` table to the *resolved* path (respects `--config`/`TIX_CONFIG_PATH`); `--force` to overwrite
- All `run()` signatures now `Result<(), TixError>`; errors centralized in `main`

Verified end-to-end: init → show → get (bare/json) → set → get round-trip, and a `set` on a file containing a `[myplugin]` table + comments left everything byte-identical apart from the edited key.

Note: `--output` stays per-subcommand until the #68 prerequisite hoists it to a global.

🤖 Generated with [Claude Code](https://claude.com/claude-code)