### PR TITLE
feat(cli,engine): implement tix ticket setup with creation-time seeds

### DIFF
--- a/tix-cli/src/tix/document.rs
+++ b/tix-cli/src/tix/document.rs
@@ -126,6 +126,30 @@ impl TixDocument {
         &mut self.doc
     }
 
+    /// Replaces the section `name` with the serialization of `value`.
+    ///
+    /// This rewrites *that section only* — the owner of a type replacing its
+    /// own table. Every other section (plugin tables, comments outside this
+    /// subtree) is untouched, which is what makes this safe where a typed
+    /// whole-document round-trip is not.
+    ///
+    /// # Errors
+    ///
+    /// [`TixError::SerializationError`] if `value` does not serialize to a
+    /// TOML table.
+    pub fn set_section<T: serde::Serialize>(
+        &mut self,
+        name: &str,
+        value: &T,
+    ) -> Result<(), TixError> {
+        let text = toml::to_string(value)?;
+        let section: toml_edit::DocumentMut = text
+            .parse()
+            .map_err(|e| TixError::Message(format!("serialized [{name}] is not a table: {e}")))?;
+        self.doc.insert(name, section.as_item().clone());
+        Ok(())
+    }
+
     /// Serializes and atomically replaces the file at `path`: write to a
     /// sibling temp file, then rename into place (atomic on POSIX,
     /// near-atomic on NTFS). Creates parent directories as needed.

--- a/tix-cli/src/tix/ticket/mod.rs
+++ b/tix-cli/src/tix/ticket/mod.rs
@@ -73,6 +73,106 @@ mod ticket_ref_tests {
     }
 }
 
+/// Derives the branch name seeded into a new worktree:
+/// `<prefix>/<key>-<sanitized-description>` (v2 parity, spec §3.4).
+///
+/// The prefix and the description are each optional and drop out cleanly:
+/// no prefix means no `<prefix>/`, no (or fully unsanitizable) description
+/// means the key alone. Derivation happens **once** — at `tix ticket setup`
+/// or `tix ticket add` — and the result is written into the ticket document;
+/// later changes to `[defaults]` never rename an existing branch.
+///
+/// # Examples
+///
+/// ```text
+/// derive_branch_name(Some("feature"), "JIRA-123", Some("Fix the Login Bug!"))
+///     == "feature/JIRA-123-fix-the-login-bug"
+/// derive_branch_name(None, "JIRA-123", None) == "JIRA-123"
+/// ```
+pub fn derive_branch_name(prefix: Option<&str>, key: &str, description: Option<&str>) -> String {
+    let sanitized = description.map(sanitize_description).unwrap_or_default();
+    let stem = if sanitized.is_empty() {
+        key.to_string()
+    } else {
+        format!("{key}-{sanitized}")
+    };
+    match prefix {
+        Some(prefix) if !prefix.is_empty() => format!("{prefix}/{stem}"),
+        _ => stem,
+    }
+}
+
+/// Lowercases, maps every non-alphanumeric run to a single `-`, trims the
+/// ends, and caps the result at 40 characters (without splitting a word run
+/// mid-hyphen cleanup).
+fn sanitize_description(description: &str) -> String {
+    const MAX_LENGTH: usize = 40;
+    let mut out = String::with_capacity(description.len());
+    for c in description.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c.to_ascii_lowercase());
+        } else if !out.is_empty() && !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    let trimmed = out.trim_end_matches('-');
+    let capped = trimmed.chars().take(MAX_LENGTH).collect::<String>();
+    capped.trim_end_matches('-').to_string()
+}
+
+#[cfg(test)]
+mod branch_name_tests {
+    use super::*;
+
+    /// Full derivation: prefix, key, sanitized description.
+    #[test]
+    fn test_full_derivation() {
+        assert_eq!(
+            derive_branch_name(Some("feature"), "JIRA-123", Some("Fix the Login Bug!")),
+            "feature/JIRA-123-fix-the-login-bug"
+        );
+    }
+
+    /// Prefix and description each drop out cleanly when absent.
+    #[test]
+    fn test_optional_parts_drop_out() {
+        assert_eq!(
+            derive_branch_name(None, "JIRA-123", Some("desc")),
+            "JIRA-123-desc"
+        );
+        assert_eq!(
+            derive_branch_name(Some("feature"), "JIRA-123", None),
+            "feature/JIRA-123"
+        );
+        assert_eq!(derive_branch_name(None, "JIRA-123", None), "JIRA-123");
+        assert_eq!(derive_branch_name(Some(""), "JIRA-123", None), "JIRA-123");
+    }
+
+    /// Sanitization collapses punctuation runs, trims, and caps length.
+    #[test]
+    fn test_sanitization() {
+        assert_eq!(sanitize_description("Fix: the (login) bug!!"), "fix-the-login-bug");
+        assert_eq!(sanitize_description("---"), "");
+        assert_eq!(
+            sanitize_description(
+                "a very long description that goes on and on and on far past the cap"
+            )
+            .len()
+                <= 40,
+            true
+        );
+    }
+
+    /// A description that sanitizes to nothing behaves like no description.
+    #[test]
+    fn test_unsanitizable_description() {
+        assert_eq!(
+            derive_branch_name(Some("feature"), "JIRA-123", Some("!!!")),
+            "feature/JIRA-123"
+        );
+    }
+}
+
 #[derive(Args)]
 pub struct TicketArgs {
     #[command(subcommand)]

--- a/tix-cli/src/tix/ticket/setup.rs
+++ b/tix-cli/src/tix/ticket/setup.rs
@@ -1,26 +1,151 @@
+//! `tix ticket setup` — create a new ticket workspace with worktrees.
+
+use crate::tix::config::CliConfig;
 use crate::tix::context::Context;
-use tix_engine::TixError;
+use crate::tix::document::TixDocument;
 use crate::tix::repo::RepoAlias;
-use crate::tix::ticket::TicketRef;
+use crate::tix::ticket::derive_branch_name;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use tix_engine::{Defaults, EngineConfig, TicketConfig, TixError, WorktreeConfig};
+use tracing::{error, info};
 
-use clap;
-
+/// Arguments for `tix ticket setup`.
 #[derive(clap::Args, Debug)]
 pub struct Args {
+    /// The ticket key, e.g. JIRA-123 (a name, not a path)
+    pub key: String,
+
+    /// Human-readable description; feeds branch name derivation
     #[arg(short, long)]
     pub description: Option<String>,
 
-    #[arg(value_hint = clap::ValueHint::DirPath)]
-    pub ticket: TicketRef,
-
+    /// Include every registered repository
     #[arg(short, long, group = "repos")]
     pub all: bool,
 
+    /// Repositories to include (defaults to [defaults].repositories)
     #[arg(group = "repos")]
     pub repo_aliases: Vec<RepoAlias>,
 }
 
-pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
-    println!("{:#?}", args);
+/// Creates `<tickets_directory>/<key>/` with a worktree per selected repo.
+///
+/// Runs **without ticket context** by design — this is the command that
+/// creates it. `[defaults]` is read **once**, here, and the derived values
+/// are written into the ticket document; later changes to `[defaults]` never
+/// touch this ticket (seeds, not defaults — spec §3.4).
+///
+/// Repo selection: explicit aliases win, `--all` takes every registered
+/// repo, and neither falls back to the `defaults.repositories` seed list.
+///
+/// Partial failure leaves successfully created worktrees in place and
+/// records only them in `.tix/ticket.toml`; the command then errors naming
+/// the repos that failed.
+pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+    if args.key.is_empty() || args.key.contains(['/', '\\']) {
+        return Err(TixError::Message(format!(
+            "'{}' is not a valid ticket key — keys are names, not paths (path-form creation is #114)",
+            args.key
+        )));
+    }
+
+    let document = TixDocument::load(&context.config_path)?;
+    let cli: CliConfig = document.section("cli")?.ok_or_else(|| {
+        TixError::Message("global config has no [cli] section — run `tix config init`".to_string())
+    })?;
+    let engine: EngineConfig = document.section_or_default("engine")?;
+    let defaults: Defaults = document.section_or_default("defaults")?;
+
+    // --- select repositories ---
+    let selected: Vec<String> = if args.all {
+        let mut aliases: Vec<String> = engine.configured_repositories.keys().cloned().collect();
+        aliases.sort();
+        aliases
+    } else if !args.repo_aliases.is_empty() {
+        args.repo_aliases.iter().map(|alias| alias.0.clone()).collect()
+    } else {
+        defaults.repositories.clone()
+    };
+    for alias in &selected {
+        if !engine.configured_repositories.contains_key(alias) {
+            let mut known: Vec<&str> = engine
+                .configured_repositories
+                .keys()
+                .map(String::as_str)
+                .collect();
+            known.sort();
+            return Err(TixError::RepoNotFound(format!(
+                "'{alias}' is not a registered repository (registered: {})",
+                if known.is_empty() { "none".to_string() } else { known.join(", ") }
+            )));
+        }
+    }
+
+    // --- seed reads: derivation happens once, now ---
+    let branch = derive_branch_name(
+        defaults.branch_prefix.as_deref(),
+        &args.key,
+        args.description.as_deref(),
+    );
+    let description = args.description.clone().unwrap_or_default();
+
+    let ticket_root: PathBuf = cli.tickets_directory.join(&args.key);
+    if ticket_root.exists() {
+        return Err(TixError::Message(format!(
+            "ticket '{}' already exists at {}",
+            args.key,
+            ticket_root.display()
+        )));
+    }
+    std::fs::create_dir_all(&ticket_root).map_err(TixError::IoError)?;
+
+    // --- create worktrees; collect successes and failures ---
+    let mut worktrees: HashMap<String, WorktreeConfig> = HashMap::new();
+    let mut failures: Vec<(String, TixError)> = Vec::new();
+    for alias in &selected {
+        let repo_config = engine.configured_repositories[alias].clone();
+        let result = repo_config
+            .ensure(alias)
+            .and_then(|repo| repo.create_worktree(alias, &branch, &ticket_root.join(alias), false));
+        match result {
+            Ok(worktree) => {
+                info!(alias = %alias, branch = %worktree.branch, "worktree created");
+                worktrees.insert(
+                    alias.clone(),
+                    WorktreeConfig {
+                        repo: alias.clone(),
+                        branch: worktree.branch,
+                    },
+                );
+            }
+            Err(e) => {
+                error!(alias = %alias, error = %e, "failed to create worktree");
+                failures.push((alias.clone(), e));
+            }
+        }
+    }
+
+    // --- write the ticket document, recording only what actually exists ---
+    let ticket = TicketConfig {
+        key: args.key.clone(),
+        description,
+        worktrees,
+    };
+    let mut ticket_document = TixDocument::empty();
+    ticket_document.set_section("ticket", &ticket)?;
+    ticket_document.save(&ticket_root.join(".tix").join("ticket.toml"))?;
+
+    println!("{}", ticket_root.display());
+
+    if !failures.is_empty() {
+        let names: Vec<&str> = failures.iter().map(|(alias, _)| alias.as_str()).collect();
+        return Err(TixError::Message(format!(
+            "ticket created, but {} of {} worktrees failed: {} — fix and `tix ticket add` them",
+            failures.len(),
+            selected.len(),
+            names.join(", ")
+        )));
+    }
     Ok(())
 }

--- a/tix-engine/src/types/repository.rs
+++ b/tix-engine/src/types/repository.rs
@@ -54,7 +54,10 @@ impl RepositoryConfig {
     pub fn resolve(self, alias: &str) -> Result<Repository, TixError> {
         debug!(alias = %alias, path = %self.code_path.display(), "opening repository");
         let repo = git2::Repository::open(&self.code_path).map_err(|e| {
-            error!(alias = %alias, error = %e, "failed to open repository");
+            // debug, not error: failing to open is an expected probe on the
+            // ensure() path (resolve-then-clone); the Err carries the story
+            // for callers that treat it as fatal.
+            debug!(alias = %alias, error = %e, "failed to open repository");
             TixError::GitError(e)
         })?;
         debug!(alias = %alias, "repository opened");
@@ -161,8 +164,9 @@ impl Repository {
     ///
     /// Syncs the repository first (fetches and fast-forwards). Pass `force: true` to discard
     /// local changes before syncing. If `branch` exists locally the worktree
-    /// checks it out; otherwise git2 falls back to creating a fresh branch
-    /// named `name` from HEAD.
+    /// checks it out; otherwise the branch is created at the synced HEAD and
+    /// the worktree opens on it — the branch name is always `branch`, never
+    /// the worktree name.
     ///
     /// # Errors
     ///
@@ -194,8 +198,25 @@ impl Repository {
         info!(alias = %self.alias, name, branch, "creating worktree");
         self.sync(force)?;
 
-        let local_branch = self.repo.find_branch(branch, git2::BranchType::Local).ok();
-        let reference = local_branch.map(|b| b.into_reference());
+        // The worktree must open on `branch` by that exact name. Without an
+        // explicit reference, git2 would create a branch named after the
+        // *worktree* — wrong the moment name and branch differ (per-worktree
+        // branches, spec §3.2).
+        let local_branch = match self.repo.find_branch(branch, git2::BranchType::Local) {
+            Ok(existing) => existing,
+            Err(_) => {
+                debug!(alias = %self.alias, branch, "branch not found locally, creating at synced HEAD");
+                let head = self
+                    .repo
+                    .head()
+                    .and_then(|h| h.peel_to_commit())
+                    .map_err(TixError::GitError)?;
+                self.repo
+                    .branch(branch, &head, false)
+                    .map_err(TixError::GitError)?
+            }
+        };
+        let reference = Some(local_branch.into_reference());
 
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(TixError::IoError)?;
@@ -204,9 +225,15 @@ impl Repository {
         let mut options = WorktreeAddOptions::new();
         options.reference(reference.as_ref());
 
+        // Git registers worktrees under a repo-unique name. The config-level
+        // `name` (directory under the ticket root) collides the moment two
+        // tickets include the same repo, so registration uses the sanitized
+        // branch instead — branches are unique per repo by git's own rules
+        // (v2 parity: repo_worktrees held sanitized names).
+        let registration = registration_name(branch);
         let worktree = self
             .repo
-            .worktree(name, path, Some(&options))
+            .worktree(&registration, path, Some(&options))
             .map(|_| Worktree {
                 name: name.to_string(),
                 branch: branch.to_string(),
@@ -221,18 +248,37 @@ impl Repository {
         Ok(worktree)
     }
 
-    /// Prunes the git worktree registered as `name` from this repository.
+    /// Finds the registered worktree whose recorded path is `path`, if any.
     ///
-    /// `name` is the worktree directory name — the same name the worktree was
-    /// created under via [`Self::create_worktree`], and the key of its entry
-    /// in [`TicketConfig::worktrees`](crate::TicketConfig::worktrees).
+    /// Paths are normalized before comparison — git records canonicalized
+    /// paths (on macOS, `/var/...` becomes `/private/var/...`), so a raw
+    /// equality check would miss legitimate matches.
+    fn find_worktree_by_path(&self, path: &Path) -> Result<Option<git2::Worktree>, TixError> {
+        let target = normalize_path(path);
+        let names = self.repo.worktrees().map_err(TixError::GitError)?;
+        for name in names.iter().filter_map(|n| n.ok().flatten()) {
+            let worktree = self.repo.find_worktree(name).map_err(TixError::GitError)?;
+            if normalize_path(worktree.path()) == target {
+                return Ok(Some(worktree));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Prunes the git worktree living at `path` from this repository.
+    ///
+    /// Lookup is by the worktree's recorded path rather than its registration
+    /// name — the path is what the ticket document knows
+    /// (`<ticket_root>/<name>`), and it stays unambiguous even for orphaned
+    /// worktrees whose directory is already gone.
     ///
     /// Pass `force: true` to remove even if the worktree is in a dirty state. Without `force`,
     /// returns an error if the worktree fails validation (e.g. has uncommitted changes).
     ///
     /// # Errors
     ///
-    /// - [`TixError::Message`] if the worktree does not exist or is dirty without `force`
+    /// - [`TixError::WorktreeNotFound`] if no registered worktree records `path`
+    /// - [`TixError::Message`] if the worktree is dirty without `force`
     /// - [`TixError::GitError`] if pruning fails
     ///
     /// # Examples
@@ -244,18 +290,17 @@ impl Repository {
     ///     "https://github.com/owner/repo.git".to_string(),
     ///     PathBuf::from("/home/user/code/repo"),
     /// ).resolve("my-repo").unwrap();
-    /// repo.remove_worktree("my-repo", false);
+    /// repo.remove_worktree(&PathBuf::from("/home/user/tickets/JIRA-123/my-repo"), false);
     /// ```
-    pub fn remove_worktree(&self, name: &str, force: bool) -> Result<(), TixError> {
-        info!(alias = %self.alias, name, "removing worktree");
+    pub fn remove_worktree(&self, path: &Path, force: bool) -> Result<(), TixError> {
+        info!(alias = %self.alias, path = %path.display(), "removing worktree");
 
         let worktree = self
-            .repo
-            .find_worktree(name)
-            .map_err(|_| TixError::from("worktree does not exist"))?;
+            .find_worktree_by_path(path)?
+            .ok_or_else(|| TixError::WorktreeNotFound(path.display().to_string()))?;
 
         if !force && worktree.validate().is_err() {
-            error!(alias = %self.alias, name, "worktree is dirty, use force to remove");
+            error!(alias = %self.alias, path = %path.display(), "worktree is dirty, use force to remove");
             return Err(TixError::from(
                 "worktree is not in a clean state, use force to remove",
             ));
@@ -265,10 +310,10 @@ impl Repository {
         opts.working_tree(true).valid(true);
 
         worktree.prune(Some(&mut opts)).map_err(|e| {
-            error!(alias = %self.alias, name, error = %e, "failed to remove worktree");
+            error!(alias = %self.alias, path = %path.display(), "failed to remove worktree: {e}");
             TixError::GitError(e)
         })?;
-        info!(alias = %self.alias, name, "worktree removed");
+        info!(alias = %self.alias, path = %path.display(), "worktree removed");
         Ok(())
     }
 
@@ -478,6 +523,31 @@ impl Repository {
     }
 }
 
+
+/// The repo-unique name a worktree is registered under: the branch with path
+/// separators flattened. Branch uniqueness per repo (enforced by git) makes
+/// this collision-free in practice; a rare sanitization collision surfaces as
+/// a clear git error at creation.
+fn registration_name(branch: &str) -> String {
+    branch.replace(['/', '\\'], "-")
+}
+
+/// Canonicalizes `path` for comparison, tolerating paths that no longer
+/// exist (an orphaned worktree's directory) by canonicalizing the parent and
+/// re-joining the final component.
+fn normalize_path(path: &Path) -> PathBuf {
+    if let Ok(canonical) = path.canonicalize() {
+        return canonical;
+    }
+    match (path.parent(), path.file_name()) {
+        (Some(parent), Some(name)) => parent
+            .canonicalize()
+            .map(|parent| parent.join(name))
+            .unwrap_or_else(|_| path.to_path_buf()),
+        _ => path.to_path_buf(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -620,6 +690,31 @@ mod tests {
         ));
     }
 
+    /// A worktree whose name differs from its branch opens on the requested
+    /// branch — created fresh when absent — never on a branch named after
+    /// the worktree.
+    #[test]
+    fn test_create_worktree_name_differs_from_branch() {
+        let dir = tempdir().unwrap();
+        let remote = test_helpers::init_bare_repo(&dir.path().join("remote"));
+        test_helpers::add_commit_to_bare(&remote, "initial commit");
+        let local = test_helpers::clone_repo(&dir.path().join("remote"), &dir.path().join("local"));
+        let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
+
+        let path = dir.path().join("worktrees/my-repo");
+        let worktree = repo
+            .create_worktree("my-repo", "feature/JIRA-1-fix", &path, false)
+            .unwrap();
+
+        assert_eq!(worktree.name, "my-repo");
+        assert_eq!(worktree.branch, "feature/JIRA-1-fix");
+        let opened = git2::Repository::open(&path).unwrap();
+        assert_eq!(
+            opened.head().unwrap().shorthand(),
+            Ok("feature/JIRA-1-fix")
+        );
+    }
+
     /// A sync failure propagates as an error before the worktree is created.
     #[test]
     fn test_create_worktree_sync_error() {
@@ -648,8 +743,8 @@ mod tests {
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
         assert!(matches!(
-            repo.remove_worktree("nonexistent", false),
-            Err(TixError::Message(_))
+            repo.remove_worktree(&dir.path().join("worktrees/nonexistent"), false),
+            Err(TixError::WorktreeNotFound(_))
         ));
     }
 
@@ -664,7 +759,7 @@ mod tests {
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
         assert!(matches!(
-            repo.remove_worktree("feature", false),
+            repo.remove_worktree(&dir.path().join("worktrees/feature"), false),
             Err(TixError::Message(_))
         ));
     }
@@ -679,7 +774,7 @@ mod tests {
         test_helpers::orphan_worktree(&local, "feature", &dir.path().join("worktrees/feature"));
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        assert!(repo.remove_worktree("feature", true).is_ok());
+        assert!(repo.remove_worktree(&dir.path().join("worktrees/feature"), true).is_ok());
     }
 
     /// Removing a valid worktree succeeds and returns `Ok(())`.
@@ -692,7 +787,7 @@ mod tests {
         test_helpers::add_worktree(&local, "feature", &dir.path().join("worktrees/feature"));
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        assert!(repo.remove_worktree("feature", false).is_ok());
+        assert!(repo.remove_worktree(&dir.path().join("worktrees/feature"), false).is_ok());
         assert!(!dir.path().join("worktrees/feature").exists());
     }
 


### PR DESCRIPTION
Closes #77. Closes #97 (the seed *reads* this issue deferred to setup — the `Defaults` shape landed in #108).

Stacked on #113 (base: `armaan/config-subcommands-83`).

**CLI**
- `tix ticket setup <key> [-d <desc>] [--all | <aliases>…]` (arg shape per scaffold, confirmed): explicit aliases > `--all` > `defaults.repositories`
- `[defaults]` read **once** at creation; branch derived as `<prefix>/<key>-<sanitized-description>` (`derive_branch_name` shared helper — #80 reuses it); results written into `.tix/ticket.toml`, so later `[defaults]` edits never touch existing tickets (verified e2e)
- Partial failure records only the worktrees that exist, then errors naming the failures and pointing at `tix ticket add`
- Keys are names, not paths; path-form creation filed as #114 (milestone 3.1)
- `TixDocument::set_section()` — one typed section replaced in the DOM, everything else untouched

**Engine fixes found by exercising the real flow**
- `create_worktree` creates the requested branch at synced HEAD when absent (git2's fallback would name the branch after the *worktree*)
- Worktree **registration** names collide across tickets sharing a repo when keyed by alias → registration now uses the sanitized branch (v2 `repo_worktrees` parity); `remove_worktree` looks up by recorded path with normalization for macOS `/var`→`/private/var`

Verified e2e with two bare remotes: setup clones via `ensure()`, opens worktrees on the derived branch, second ticket on the same repos works (the collision case), duplicate setup and unknown aliases error cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)