### PR TITLE
feat(cli): implement tix ticket list

### DIFF
--- a/tix-cli/src/main.rs
+++ b/tix-cli/src/main.rs
@@ -18,9 +18,11 @@ fn main() {
     let parsed = tix::TixParser::parse();
     let log_level = parsed.resolve_log_level();
 
+    // Diagnostics go to stderr: stdout carries results only, so
+    // `tix ticket list --output json | jq` works even when warnings fire.
     fmt()
         .with_max_level(log_level)
-        .with_writer(std::io::stdout)
+        .with_writer(std::io::stderr)
         .init();
 
     // Resolve the config path once (--config > TIX_CONFIG_PATH > platform

--- a/tix-cli/src/tix/ticket/list.rs
+++ b/tix-cli/src/tix/ticket/list.rs
@@ -1,15 +1,90 @@
-use crate::tix::context::Context;
-use tix_engine::TixError;
-use super::TicketSharedArgs;
-use clap;
+//! `tix ticket list` — one line per ticket under the tickets directory.
 
+use crate::tix::context::Context;
+use crate::tix::document::TixDocument;
+use crate::tix::ticket::load_cli_config;
+use crate::tix::utils::OutputType;
+use tix_engine::{TicketConfig, TixError};
+use tracing::warn;
+
+/// Arguments for `tix ticket list`.
 #[derive(clap::Args, Debug)]
 pub struct Args {
-    #[command(flatten)]
-    pub shared: TicketSharedArgs,
+    /// Output format
+    #[arg(short, long)]
+    pub output: Option<OutputType>,
 }
 
-pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
-    println!("{:#?}", args);
+/// Lists every ticket under `tickets_directory`.
+///
+/// Reads only `[ticket]` sections — no live `Ticket` resolution and no
+/// worktree scanning, so listing stays fast on large ticket sets (directory
+/// layout is frontend policy; the engine is never involved). Directories
+/// without a `.tix/ticket.toml` are silently skipped; one with a malformed
+/// document warns and is skipped — a broken ticket never breaks the listing.
+pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+    let cli = load_cli_config(context)?;
+
+    let mut tickets: Vec<TicketConfig> = Vec::new();
+    let entries = match std::fs::read_dir(&cli.tickets_directory) {
+        Ok(entries) => entries,
+        Err(_) => {
+            // No tickets directory yet simply means no tickets.
+            print_tickets(&tickets, args.output.unwrap_or(OutputType::Default))?;
+            return Ok(());
+        }
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let ticket_path = entry.path().join(".tix").join("ticket.toml");
+        if !ticket_path.is_file() {
+            continue;
+        }
+        let parsed: Result<Option<TicketConfig>, TixError> =
+            TixDocument::load(&ticket_path).and_then(|doc| doc.section("ticket"));
+        match parsed {
+            Ok(Some(ticket)) => tickets.push(ticket),
+            Ok(None) => warn!(path = %ticket_path.display(), "no [ticket] section — skipping"),
+            Err(e) => warn!(path = %ticket_path.display(), error = %e, "malformed ticket document — skipping"),
+        }
+    }
+    tickets.sort_by(|a, b| a.key.cmp(&b.key));
+
+    print_tickets(&tickets, args.output.unwrap_or(OutputType::Default))?;
+    Ok(())
+}
+
+/// Renders the listing in the requested format.
+fn print_tickets(tickets: &[TicketConfig], output: OutputType) -> Result<(), TixError> {
+    match output {
+        OutputType::Default => {
+            let width = tickets.iter().map(|t| t.key.len()).max().unwrap_or(0);
+            for ticket in tickets {
+                if ticket.description.is_empty() {
+                    println!("{}", ticket.key);
+                } else {
+                    println!("{:width$}  {}", ticket.key, ticket.description);
+                }
+            }
+        }
+        OutputType::Json => {
+            let entries: Vec<serde_json::Value> = tickets
+                .iter()
+                .map(|t| {
+                    serde_json::json!({
+                        "key": t.key,
+                        "description": t.description,
+                        "worktrees": t.worktrees.len(),
+                    })
+                })
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&entries).unwrap());
+        }
+        OutputType::Toml => {
+            for ticket in tickets {
+                let text = toml::to_string(ticket)?;
+                println!("[[ticket]]\n{text}");
+            }
+        }
+    }
     Ok(())
 }

--- a/tix-cli/src/tix/ticket/mod.rs
+++ b/tix-cli/src/tix/ticket/mod.rs
@@ -173,6 +173,58 @@ mod branch_name_tests {
     }
 }
 
+/// Loads the required `[cli]` section from the resolved global config.
+///
+/// Shared by every ticket subcommand; the "no [cli] section" error points at
+/// `tix config init` rather than leaking a parse detail.
+pub fn load_cli_config(
+    context: &crate::tix::context::Context,
+) -> Result<crate::tix::config::CliConfig, tix_engine::TixError> {
+    let document = crate::tix::document::TixDocument::load(&context.config_path)?;
+    document.section("cli")?.ok_or_else(|| {
+        tix_engine::TixError::Message(
+            "global config has no [cli] section — run `tix config init`".to_string(),
+        )
+    })
+}
+
+/// Reads the `[ticket]` section of the ticket document at `ticket_root`.
+///
+/// # Errors
+///
+/// [`tix_engine::TixError::TicketNotFound`] when the document has no
+/// `[ticket]` section; parse errors propagate from the document layer.
+pub fn load_ticket_config(
+    ticket_root: &std::path::Path,
+) -> Result<tix_engine::TicketConfig, tix_engine::TixError> {
+    let document =
+        crate::tix::document::TixDocument::load(&ticket_root.join(".tix").join("ticket.toml"))?;
+    document.section("ticket")?.ok_or_else(|| {
+        tix_engine::TixError::TicketNotFound(format!(
+            "{} has no [ticket] section",
+            ticket_root.join(".tix/ticket.toml").display()
+        ))
+    })
+}
+
+/// Resolves the ticket a command operates on — `--ticket` override or the
+/// discovery walk — and errors clearly when neither yields one.
+///
+/// The error is the "requires ticket context" message every ticket-scoped
+/// command shares; commands that merely prefer context call the discovery
+/// layer directly.
+pub fn require_ticket_root(
+    context: &crate::tix::context::Context,
+    ticket: Option<&TicketRef>,
+) -> Result<std::path::PathBuf, tix_engine::TixError> {
+    let cli = load_cli_config(context)?;
+    crate::tix::discovery::resolve_ticket_root(ticket, &cli.tickets_directory)?.ok_or_else(|| {
+        tix_engine::TixError::TicketNotFound(
+            "not inside a ticket — cd into one or pass --ticket <path|id>".to_string(),
+        )
+    })
+}
+
 #[derive(Args)]
 pub struct TicketArgs {
     #[command(subcommand)]


### PR DESCRIPTION
Closes #78

Stacked on #115 (base: `armaan/ticket-setup-77`).

- Scans `tickets_directory` for the file `.tix/ticket.toml`; parses `[ticket]` via the document layer; prints `KEY  description` aligned, sorted by key
- No live resolution / worktree scanning — fast on large sets by construction
- Malformed document → warn + skip (verified e2e); missing document → silent skip; missing tickets directory → empty listing
- `--output json` (includes worktree count) and `--output toml`
- Shared helpers for the subcommand family: `load_cli_config`, `load_ticket_config`, `require_ticket_root`
- Tracing moved to stderr so JSON output stays pipeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)