### PR TITLE
feat(cli): implement tix ticket info

### DIFF
--- a/tix-cli/src/tix/ticket/info.rs
+++ b/tix-cli/src/tix/ticket/info.rs
@@ -1,15 +1,146 @@
-use crate::tix::context::Context;
-use tix_engine::TixError;
-use super::TicketSharedArgs;
-use clap;
+//! `tix ticket info` — display a ticket's metadata and worktree table.
 
+use crate::tix::context::Context;
+use crate::tix::ticket::{TicketSharedArgs, load_ticket_config, require_ticket_root};
+use crate::tix::utils::OutputType;
+use std::path::{Path, PathBuf};
+use tix_engine::{TicketConfig, TixError};
+
+/// Arguments for `tix ticket info`.
 #[derive(clap::Args, Debug)]
 pub struct Args {
     #[command(flatten)]
     pub shared: TicketSharedArgs,
+
+    /// Output format
+    #[arg(short, long)]
+    pub output: Option<OutputType>,
 }
 
-pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
-    println!("{:#?}", args);
+/// One row of the worktree table: recorded state plus its on-disk status.
+struct WorktreeRow {
+    name: String,
+    repo: String,
+    branch: String,
+    path: PathBuf,
+    status: WorktreeStatus,
+}
+
+/// Whether a recorded worktree actually resolves on disk.
+enum WorktreeStatus {
+    Ok,
+    MissingDirectory,
+    NotAGitRepository,
+}
+
+impl WorktreeStatus {
+    fn of(path: &Path) -> Self {
+        if !path.is_dir() {
+            WorktreeStatus::MissingDirectory
+        } else if !tix_engine::opens_as_git_repository(path) {
+            WorktreeStatus::NotAGitRepository
+        } else {
+            WorktreeStatus::Ok
+        }
+    }
+
+    fn marker(&self) -> &'static str {
+        match self {
+            WorktreeStatus::Ok => "",
+            WorktreeStatus::MissingDirectory => "  ⚠ missing on disk",
+            WorktreeStatus::NotAGitRepository => "  ⚠ not a git repository",
+        }
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            WorktreeStatus::Ok => "ok",
+            WorktreeStatus::MissingDirectory => "missing",
+            WorktreeStatus::NotAGitRepository => "not-a-git-repository",
+        }
+    }
+}
+
+/// Prints key, description, path, and the per-repo worktree table.
+///
+/// Pure frontend over the recorded `[ticket]` section: each worktree is
+/// checked individually so one that fails to resolve renders with a warning
+/// marker instead of failing the whole command — which is also why this does
+/// not go through the all-or-nothing [`TicketConfig::resolve`].
+///
+/// There is deliberately no single ticket branch to print: branches are
+/// per-worktree (spec §3.2).
+pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+    let root = require_ticket_root(context, args.shared.ticket.as_ref())?;
+    let ticket: TicketConfig = load_ticket_config(&root)?;
+
+    // Grouped by repo, then by name within a repo.
+    let mut rows: Vec<WorktreeRow> = ticket
+        .worktrees
+        .iter()
+        .map(|(name, entry)| {
+            let path = root.join(name);
+            WorktreeRow {
+                name: name.clone(),
+                repo: entry.repo.clone(),
+                branch: entry.branch.clone(),
+                status: WorktreeStatus::of(&path),
+                path,
+            }
+        })
+        .collect();
+    rows.sort_by(|a, b| a.repo.cmp(&b.repo).then(a.name.cmp(&b.name)));
+
+    match args.output.unwrap_or(OutputType::Default) {
+        OutputType::Default => {
+            if ticket.description.is_empty() {
+                println!("{}", ticket.key);
+            } else {
+                println!("{}  {}", ticket.key, ticket.description);
+            }
+            println!("{}", root.display());
+            if rows.is_empty() {
+                println!("\nno worktrees");
+            } else {
+                let name_width = rows.iter().map(|r| r.name.len()).max().unwrap_or(0);
+                let repo_width = rows.iter().map(|r| r.repo.len()).max().unwrap_or(0);
+                println!();
+                for row in &rows {
+                    println!(
+                        "{:name_width$}  {:repo_width$}  {}{}",
+                        row.name,
+                        row.repo,
+                        row.branch,
+                        row.status.marker()
+                    );
+                }
+            }
+        }
+        OutputType::Json => {
+            let worktrees: Vec<serde_json::Value> = rows
+                .iter()
+                .map(|row| {
+                    serde_json::json!({
+                        "name": row.name,
+                        "repo": row.repo,
+                        "branch": row.branch,
+                        "path": row.path,
+                        "status": row.status.label(),
+                    })
+                })
+                .collect();
+            let value = serde_json::json!({
+                "key": ticket.key,
+                "description": ticket.description,
+                "path": root,
+                "worktrees": worktrees,
+            });
+            println!("{}", serde_json::to_string_pretty(&value).unwrap());
+        }
+        OutputType::Toml => {
+            println!("path = {:?}\n", root.display().to_string());
+            print!("{}", toml::to_string(&ticket)?);
+        }
+    }
     Ok(())
 }

--- a/tix-engine/src/lib.rs
+++ b/tix-engine/src/lib.rs
@@ -33,6 +33,7 @@ mod types;
 mod utils;
 
 pub use types::config::EngineConfig;
+pub use utils::opens_as_git_repository;
 pub use types::defaults::Defaults;
 pub use types::errors::TixError;
 pub use types::repository::Repository;

--- a/tix-engine/src/utils.rs
+++ b/tix-engine/src/utils.rs
@@ -1,1 +1,20 @@
+//! Small domain probes over resolved paths.
 
+use std::path::Path;
+
+/// Returns true when `path` opens as a git repository (a worktree checkout
+/// counts — its `.git` file resolves to the parent repo).
+///
+/// A probe, not a promise: frontends use this for status displays where a
+/// broken worktree should render as a warning rather than abort — the
+/// all-or-nothing path is [`TicketConfig::resolve`](crate::TicketConfig::resolve).
+///
+/// # Examples
+///
+/// ```
+/// # use std::path::Path;
+/// assert!(!tix_engine::opens_as_git_repository(Path::new("/definitely/not/a/repo")));
+/// ```
+pub fn opens_as_git_repository(path: &Path) -> bool {
+    git2::Repository::open(path).is_ok()
+}


### PR DESCRIPTION
Closes #82

Stacked on #116 (base: `armaan/ticket-list-78`).

- `tix info` / `tix ticket info [--ticket <path|id>]`: key, description, ticket path, worktree table grouped by repo (name / repo / branch per row — no single ticket branch exists to print, spec §3.2)
- Per-worktree probing: `⚠ missing on disk` / `⚠ not a git repository` markers instead of command failure; probe added engine-side (`opens_as_git_repository`) so the CLI keeps no `git2` edge
- `--output json` with per-worktree `status` labels; `--output toml`

Verified e2e: discovery from inside a worktree subdirectory, `--ticket JIRA-2` from anywhere, warning marker after deleting a worktree, JSON output, and the `tix info` top-level alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)