### PR TITLE
feat(cli,engine): implement tix ticket remove; real dirty-worktree detection

### DIFF
--- a/tix-cli/src/tix/ticket/remove.rs
+++ b/tix-cli/src/tix/ticket/remove.rs
@@ -1,19 +1,81 @@
+//! `tix ticket remove` — remove single worktrees from a ticket without
+//! destroying it.
+
 use crate::tix::context::Context;
-use tix_engine::TixError;
-use super::TicketSharedArgs;
-use crate::tix::repo::RepoAlias;
+use crate::tix::document::{TixDocument, with_write};
+use crate::tix::ticket::{TicketSharedArgs, load_ticket_config, require_ticket_root};
+use tix_engine::{EngineConfig, TixError};
+use tracing::info;
 
-use clap;
-
+/// Arguments for `tix ticket remove`.
 #[derive(clap::Args, Debug)]
 pub struct Args {
     #[command(flatten)]
     pub shared: TicketSharedArgs,
 
-    pub repo_aliases: Vec<RepoAlias>,
+    /// Worktree name(s) from the ticket's worktree map (a bare repo alias
+    /// matches its default worktree)
+    #[arg(required = true, value_name = "NAME")]
+    pub names: Vec<String>,
 }
 
-pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
-    println!("{:#?}", args);
+/// Prunes the named worktrees and deletes their entries from the ticket
+/// document.
+///
+/// `<name>` addresses the **worktree directory name** — the ticket map's key
+/// — not a repo alias: with #85 a repo can have several worktrees, so the
+/// alias alone is not an address. In the single-worktree case they coincide
+/// (`name == alias`), which is what makes bare-alias usage work today.
+///
+/// The ticket directory and every other worktree are untouched; removing
+/// the last worktree leaves a valid, empty ticket. Each successful prune is
+/// written back immediately through the format-preserving layer.
+pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+    let root = require_ticket_root(context, args.shared.ticket.as_ref())?;
+    let ticket = load_ticket_config(&root)?;
+
+    let document = TixDocument::load(&context.config_path)?;
+    let engine: EngineConfig = document.section_or_default("engine")?;
+
+    // Validate the batch up front: every name must be tracked, and every
+    // backing repo must still be registered (pruning goes through the repo).
+    let mut tracked: Vec<&str> = ticket.worktrees.keys().map(String::as_str).collect();
+    tracked.sort();
+    for name in &args.names {
+        let entry = ticket.worktrees.get(name).ok_or_else(|| {
+            TixError::WorktreeNotFound(format!(
+                "'{}' is not a tracked worktree of ticket '{}' (tracked: {})",
+                name,
+                ticket.key,
+                if tracked.is_empty() { "none".to_string() } else { tracked.join(", ") }
+            ))
+        })?;
+        if !engine.configured_repositories.contains_key(&entry.repo) {
+            return Err(TixError::RepoNotFound(format!(
+                "worktree '{}' belongs to '{}', which is no longer a registered repository",
+                name, entry.repo
+            )));
+        }
+    }
+
+    let ticket_document_path = root.join(".tix").join("ticket.toml");
+    for name in &args.names {
+        let entry = &ticket.worktrees[name];
+        let repo = engine.configured_repositories[&entry.repo]
+            .clone()
+            .resolve(&entry.repo)?;
+        repo.remove_worktree(&root.join(name), false)?;
+        info!(name = %name, repo = %entry.repo, "worktree removed");
+
+        // Drop the entry as soon as the prune lands, so an error later in
+        // the batch leaves the document agreeing with disk.
+        with_write(&ticket_document_path, |doc| {
+            if let Some(worktrees) = doc.doc_mut()["ticket"]["worktrees"].as_table_mut() {
+                worktrees.remove(name);
+            }
+            Ok(())
+        })?;
+        println!("removed {name}");
+    }
     Ok(())
 }

--- a/tix-engine/src/types/repository.rs
+++ b/tix-engine/src/types/repository.rs
@@ -299,11 +299,25 @@ impl Repository {
             .find_worktree_by_path(path)?
             .ok_or_else(|| TixError::WorktreeNotFound(path.display().to_string()))?;
 
-        if !force && worktree.validate().is_err() {
-            error!(alias = %self.alias, path = %path.display(), "worktree is dirty, use force to remove");
-            return Err(TixError::from(
-                "worktree is not in a clean state, use force to remove",
-            ));
+        if !force {
+            // validate() catches structural breakage (e.g. the directory is
+            // gone). It says nothing about cleanliness — that takes opening
+            // the worktree and asking for its status.
+            if worktree.validate().is_err() {
+                error!(alias = %self.alias, path = %path.display(), "worktree failed validation, use force to remove");
+                return Err(TixError::from(
+                    "worktree is not in a clean state, use force to remove",
+                ));
+            }
+            let worktree_repo =
+                git2::Repository::open(worktree.path()).map_err(TixError::GitError)?;
+            let statuses = worktree_repo.statuses(None).map_err(TixError::GitError)?;
+            if !statuses.is_empty() {
+                error!(alias = %self.alias, path = %path.display(), count = statuses.len(), "worktree has uncommitted changes, use force to remove");
+                return Err(TixError::from(
+                    "worktree has uncommitted changes, use force to remove",
+                ));
+            }
         }
 
         let mut opts = git2::WorktreePruneOptions::new();
@@ -774,6 +788,26 @@ mod tests {
         test_helpers::orphan_worktree(&local, "feature", &dir.path().join("worktrees/feature"));
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
+        assert!(repo.remove_worktree(&dir.path().join("worktrees/feature"), true).is_ok());
+    }
+
+    /// A worktree with uncommitted changes refuses removal without `force` —
+    /// git2's `validate()` alone would pass it.
+    #[test]
+    fn test_remove_worktree_dirty_no_force() {
+        let dir = tempdir().unwrap();
+        let remote = test_helpers::init_bare_repo(&dir.path().join("remote"));
+        test_helpers::add_commit_to_bare(&remote, "initial commit");
+        let local = test_helpers::clone_repo(&dir.path().join("remote"), &dir.path().join("local"));
+        test_helpers::add_worktree(&local, "feature", &dir.path().join("worktrees/feature"));
+        std::fs::write(dir.path().join("worktrees/feature/dirty.txt"), "wip").unwrap();
+        let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
+
+        assert!(matches!(
+            repo.remove_worktree(&dir.path().join("worktrees/feature"), false),
+            Err(TixError::Message(_))
+        ));
+        // Force discards it.
         assert!(repo.remove_worktree(&dir.path().join("worktrees/feature"), true).is_ok());
     }
 


### PR DESCRIPTION
Closes #81

Stacked on #118 (base: `armaan/ticket-add-80`).

- `tix ticket remove <name>… [--ticket <path|id>]`: name = worktree map key (bare alias hits its default worktree, `name == alias`)
- Unknown name errors listing the ticket's tracked names; a backing repo no longer registered errors up front
- Prune → immediate entry deletion via `with_write`, so the document always agrees with disk mid-batch; other worktrees and the ticket dir untouched; last-worktree removal leaves a valid empty ticket
- **Engine fix:** the dirty check in `remove_worktree` was a no-op — `git2::Worktree::validate()` is structural only, so uncommitted changes were silently discarded on the no-force path. Now opens the worktree and refuses on non-empty `statuses()`; regression test included.

Verified e2e: unknown-name error, dirty refusal (entry stays tracked), clean removal, plugin table/comments intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)