### PR TITLE
feat(cli): implement tix repo clone

### DIFF
--- a/tix-cli/src/tix/repo/clone.rs
+++ b/tix-cli/src/tix/repo/clone.rs
@@ -1,15 +1,76 @@
+//! `tix repo clone` — clone registered repositories to their code paths.
+
 use crate::tix::context::Context;
-use tix_engine::TixError;
+use crate::tix::document::TixDocument;
 use crate::tix::repo::RepoAlias;
+use tix_engine::{EngineConfig, TixError};
+use tracing::error;
 
-use clap;
-
+/// Arguments for `tix repo clone`.
 #[derive(clap::Args, Debug)]
+#[group(required = true, multiple = false)]
 pub struct Args {
+    /// Clone every registered repository not already on disk
+    #[arg(short, long, group = "targets")]
+    pub all: bool,
+
+    /// Registered aliases to clone
+    #[arg(group = "targets")]
     pub repo_aliases: Vec<RepoAlias>,
 }
 
-pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
-    println!("{:#?}", args);
+/// Clones each target via [`RepositoryConfig::ensure`] — a repo already on
+/// disk is a reported no-op, not an error.
+///
+/// The batch never aborts on one failure: every target is attempted, each
+/// outcome is reported on its own line, and the exit is nonzero if anything
+/// failed. Unknown aliases error up front listing the registered set.
+pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+    let document = TixDocument::load(&context.config_path)?;
+    let engine: EngineConfig = document.section_or_default("engine")?;
+
+    let mut registered: Vec<&str> = engine
+        .configured_repositories
+        .keys()
+        .map(String::as_str)
+        .collect();
+    registered.sort();
+
+    let targets: Vec<String> = if args.all {
+        registered.iter().map(|s| s.to_string()).collect()
+    } else {
+        for alias in &args.repo_aliases {
+            if !engine.configured_repositories.contains_key(&alias.0) {
+                return Err(TixError::RepoNotFound(format!(
+                    "'{}' is not a registered repository (registered: {})",
+                    alias.0,
+                    if registered.is_empty() { "none".to_string() } else { registered.join(", ") }
+                )));
+            }
+        }
+        args.repo_aliases.iter().map(|alias| alias.0.clone()).collect()
+    };
+
+    let mut failed = 0usize;
+    for alias in &targets {
+        let config = engine.configured_repositories[alias].clone();
+        let already_present = config.code_path.exists();
+        match config.ensure(alias) {
+            Ok(_) if already_present => println!("{alias}: already on disk"),
+            Ok(repo) => println!("{alias}: cloned to {}", repo.config.code_path.display()),
+            Err(e) => {
+                error!(alias = %alias, error = %e, "clone failed");
+                println!("{alias}: FAILED ({e})");
+                failed += 1;
+            }
+        }
+    }
+
+    if failed > 0 {
+        return Err(TixError::Message(format!(
+            "{failed} of {} clones failed",
+            targets.len()
+        )));
+    }
     Ok(())
 }


### PR DESCRIPTION
Closes #65

Stacked on #121 (base: `armaan/repo-add-63`).

- `tix repo clone <alias>… | --all` (exactly one required, enforced by clap group)
- `ensure()` per target: present → "already on disk" no-op; absent → clone; failure → per-repo `FAILED (<cause>)` line, batch continues, exit nonzero if any failed
- Unknown alias errors up front listing registered aliases

Verified e2e: clone, idempotent second run, unknown alias, `--all` with mixed present/failed outcomes (continues + nonzero), missing-args rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)