### PR TITLE
feat(cli): implement completions subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,6 +911,7 @@ name = "tix-cli"
 version = "3.0.0"
 dependencies = [
  "clap",
+ "clap_complete",
  "dirs",
  "serde",
  "serde_json",

--- a/tix-cli/Cargo.toml
+++ b/tix-cli/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.6.1", features = ["color", "derive"] }
+clap_complete = "4.6.9"
 dirs = "6.0.0"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"

--- a/tix-cli/src/main.rs
+++ b/tix-cli/src/main.rs
@@ -65,6 +65,7 @@ fn main() {
         Commands::List(args) => ticket::list::run(&context, args),
         Commands::Remove(args) => ticket::remove::run(&context, args),
         Commands::Setup(args) => ticket::setup::run(&context, args),
+        Commands::Completions(args) => cli::completions::run(&context, args),
 
         Commands::External(args) => plugin::run(&context, args),
     };

--- a/tix-cli/src/tix/cli/completions.rs
+++ b/tix-cli/src/tix/cli/completions.rs
@@ -1,20 +1,37 @@
+//! `tix completions` — shell completion generation for built-in commands.
+//!
+//! Third-party plugin completions are not tix's problem: plugins are external
+//! binaries with their own interfaces.
+
 use crate::tix::context::Context;
+use clap::CommandFactory;
 use tix_engine::TixError;
-use clap;
 
-#[derive(Debug, Clone, PartialEq, Eq, clap::ValueEnum)]
-pub enum Shells {
-    Zsh,
-    Bash,
-    Fish,
-}
-
+/// Arguments for `tix completions`.
 #[derive(clap::Args, Debug)]
+#[command(after_help = "\
+Installation:
+  bash:        tix completions bash > /etc/bash_completion.d/tix
+               (or: ~/.local/share/bash-completion/completions/tix)
+  zsh:         tix completions zsh > ~/.zfunc/_tix
+               (with `fpath+=~/.zfunc; autoload -Uz compinit; compinit` in ~/.zshrc)
+  fish:        tix completions fish > ~/.config/fish/completions/tix.fish
+  elvish:      tix completions elvish > ~/.config/elvish/lib/tix.elv
+  powershell:  tix completions powershell >> $PROFILE")]
 pub struct Args {
-    pub shell: Shells,
+    /// The shell to generate completions for
+    pub shell: clap_complete::Shell,
 }
 
+/// Generates completions from the clap command definition onto stdout — the
+/// user pipes them into their shell's completion path (see `--help`).
 pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
-    println!("{:#?}", args);
+    let mut command = crate::tix::TixParser::command();
+    clap_complete::generate(
+        args.shell,
+        &mut command,
+        "tix",
+        &mut std::io::stdout().lock(),
+    );
     Ok(())
 }

--- a/tix-cli/src/tix/mod.rs
+++ b/tix-cli/src/tix/mod.rs
@@ -78,6 +78,9 @@ pub enum Commands {
     Remove(crate::tix::ticket::remove::Args),
     Setup(crate::tix::ticket::setup::Args),
 
+    /// Generate shell completions (top-level alias for `tix cli completions`)
+    Completions(crate::tix::cli::completions::Args),
+
     #[command(external_subcommand)]
     External(Vec<String>),
 }
@@ -95,7 +98,7 @@ impl Commands {
                 command: config::ConfigCommands::Init(_),
             }) | Commands::Cli(cli::CliArgs {
                 command: cli::CliCommands::Completions(_),
-            })
+            }) | Commands::Completions(_)
         )
     }
 }


### PR DESCRIPTION
Closes #71

Stacked on #122 (base: `armaan/repo-clone-65`).

- `tix completions <bash|zsh|fish|elvish|powershell>` via `clap_complete`, generated from the live clap definition, stdout only
- Per-shell installation hints in `tix completions --help`
- Top-level `tix completions` added (the issue's form) alongside `tix cli completions`; both exempt from the config-must-exist gate
- Verified: zsh script generates (`#compdef tix`, completes `repo`), works with no config present

🤖 Generated with [Claude Code](https://claude.com/claude-code)