### PR TITLE
feat(cli): append Plugins section to root help from PATH scan

### DIFF
--- a/tix-cli/src/main.rs
+++ b/tix-cli/src/main.rs
@@ -15,7 +15,7 @@ fn fail(error: tix_engine::TixError) -> ! {
 }
 
 fn main() {
-    let parsed = tix::TixParser::parse();
+    let parsed = tix::TixParser::parse_with_plugin_help();
     let log_level = parsed.resolve_log_level();
 
     // Diagnostics go to stderr: stdout carries results only, so

--- a/tix-cli/src/tix/mod.rs
+++ b/tix-cli/src/tix/mod.rs
@@ -7,11 +7,12 @@ pub mod context;
 pub mod discovery;
 pub mod document;
 pub mod plugin;
+pub mod plugin_listing;
 pub mod utils;
 
 // ---
 
-use clap::{CommandFactory, Parser, Subcommand, error::ErrorKind};
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand, error::ErrorKind};
 use std::path::PathBuf;
 
 use crate::tix::utils::styles;
@@ -41,6 +42,27 @@ pub struct TixParser {
 }
 
 impl TixParser {
+    /// Parses argv, appending the "Plugins" section to **root** help.
+    ///
+    /// The section is built only when root help is about to render
+    /// (`tix -h`, `tix --help`, bare `tix help`) — plugin discovery execs
+    /// `print-cli-help` handshakes, which must not run on every invocation.
+    /// Subcommand help (`tix repo --help`) is untouched: plugins are
+    /// top-level commands only.
+    pub fn parse_with_plugin_help() -> Self {
+        let mut command = TixParser::command();
+        if root_help_requested() {
+            if let Some(section) = plugin_listing::plugins_help_section() {
+                command = command.after_help(section);
+            }
+        }
+        let mut matches = command.get_matches();
+        match TixParser::from_arg_matches_mut(&mut matches) {
+            Ok(parsed) => parsed,
+            Err(e) => e.format(&mut TixParser::command()).exit(),
+        }
+    }
+
     pub fn resolve_log_level(&self) -> tracing::Level {
         let flags = [self.log_level.is_some(), self.verbose, self.quiet];
 
@@ -62,6 +84,26 @@ impl TixParser {
         }
         self.log_level.unwrap_or(tracing::Level::INFO)
     }
+}
+
+/// True when this invocation renders the **root** help: the first
+/// non-global-flag token is `-h`/`--help`, or it is a bare `help` with no
+/// subcommand after it.
+fn root_help_requested() -> bool {
+    let mut args = std::env::args().skip(1).peekable();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "-h" | "--help" => return true,
+            "help" => return args.peek().is_none(),
+            // Global flags (and their values) may precede the subcommand.
+            "-v" | "--verbose" | "-q" | "--quiet" => continue,
+            "--log-level" | "--config" => {
+                args.next();
+            }
+            _ => return false,
+        }
+    }
+    false
 }
 
 #[derive(Subcommand)]

--- a/tix-cli/src/tix/plugin_listing.rs
+++ b/tix-cli/src/tix/plugin_listing.rs
@@ -1,0 +1,167 @@
+//! Plugin discovery for `tix --help` — the "Plugins" section
+//! (`design/spec.md` §5.6).
+//!
+//! Listing is best-effort by contract: a plugin whose handshake is missing,
+//! broken, slow, or malicious degrades to its bare name. **The listing
+//! itself never fails**, and handshake output is treated as untrusted input.
+
+use std::collections::BTreeMap;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+use tracing::debug;
+
+/// How long one `print-cli-help` handshake may run before it is killed.
+const HANDSHAKE_DEADLINE: Duration = Duration::from_millis(300);
+
+/// Longest description rendered next to a plugin name.
+const DESCRIPTION_CAP: usize = 100;
+
+/// Builds the "Plugins:" help section, or `None` when no plugins are on
+/// `PATH` — zero plugins simply omits the section.
+pub fn plugins_help_section() -> Option<String> {
+    let plugins = discover_plugins();
+    if plugins.is_empty() {
+        return None;
+    }
+
+    let width = plugins.keys().map(String::len).max().unwrap_or(0);
+    let mut section = String::from("Plugins:\n");
+    for (name, path) in &plugins {
+        match handshake_description(path) {
+            Some(description) => {
+                section.push_str(&format!("  {name:width$}  {description}\n"));
+            }
+            None => section.push_str(&format!("  {name}\n")),
+        }
+    }
+    section.pop(); // trailing newline
+    Some(section)
+}
+
+/// Scans every `PATH` directory for executables named `tix-*`.
+///
+/// Deduplicated by name with the **first** match on `PATH` winning (shell
+/// semantics); the `tix-` prefix is stripped for display. Returned sorted by
+/// name (BTreeMap) for stable output.
+fn discover_plugins() -> BTreeMap<String, PathBuf> {
+    let mut plugins: BTreeMap<String, PathBuf> = BTreeMap::new();
+    let Some(path_var) = std::env::var_os("PATH") else {
+        return plugins;
+    };
+    for dir in std::env::split_paths(&path_var) {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.filter_map(Result::ok) {
+            let file_name = entry.file_name();
+            let Some(name) = file_name.to_str() else {
+                continue;
+            };
+            let Some(stripped) = name.strip_prefix("tix-") else {
+                continue;
+            };
+            if stripped.is_empty() || !is_executable_file(&entry.path()) {
+                continue;
+            }
+            // First match on PATH wins; later directories don't override.
+            plugins
+                .entry(stripped.to_string())
+                .or_insert_with(|| entry.path());
+        }
+    }
+    plugins
+}
+
+/// Runs `<plugin> print-cli-help` **bare** — no `--tix-*` flags — and
+/// returns a sanitized one-line description.
+///
+/// Any failure shape (spawn error, nonzero exit, timeout, empty or garbage
+/// output) degrades to `None`: the plugin still lists by name.
+fn handshake_description(plugin: &Path) -> Option<String> {
+    let mut child = std::process::Command::new(plugin)
+        .arg("print-cli-help")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()?;
+
+    // Poll rather than block: a hung plugin must not hang `tix --help`.
+    let deadline = Instant::now() + HANDSHAKE_DEADLINE;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            _ => {
+                debug!(plugin = %plugin.display(), "handshake timed out or errored — killing");
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    };
+    if !status.success() {
+        return None;
+    }
+
+    // Bounded read: output is untrusted, so never slurp unbounded bytes.
+    let mut raw = Vec::with_capacity(512);
+    child
+        .stdout
+        .take()?
+        .take(4096)
+        .read_to_end(&mut raw)
+        .ok()?;
+    sanitize(&raw)
+}
+
+/// Strips the handshake output down to one printable line, capped.
+fn sanitize(raw: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(raw);
+    let line = text.lines().find(|line| !line.trim().is_empty())?;
+    let clean: String = line
+        .chars()
+        .filter(|c| !c.is_control())
+        .take(DESCRIPTION_CAP)
+        .collect();
+    let clean = clean.trim().to_string();
+    (!clean.is_empty()).then_some(clean)
+}
+
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.metadata()
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &Path) -> bool {
+    path.is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One printable line survives; control characters and later lines don't.
+    #[test]
+    fn test_sanitize_strips_and_caps() {
+        assert_eq!(
+            sanitize(b"deploys things\nsecond line ignored").as_deref(),
+            Some("deploys things")
+        );
+        assert_eq!(
+            sanitize(b"\x1b[31mred\x07 alert\x1b[0m").as_deref(),
+            Some("[31mred alert[0m")
+        );
+        assert_eq!(sanitize(b"").as_deref(), None);
+        assert_eq!(sanitize(b"\n\n   \n").as_deref(), None);
+        let long = vec![b'a'; 500];
+        assert_eq!(sanitize(&long).unwrap().len(), DESCRIPTION_CAP);
+    }
+}


### PR DESCRIPTION
Closes #70

Stacked on #123 (base: `armaan/completions-71`).

- PATH scan for executable `tix-*`; dedupe first-on-PATH wins; prefix stripped; sorted, aligned listing appended via `after_help`
- Optional `print-cli-help` handshake, invoked **bare**; 300ms poll-then-kill deadline; nonzero/garbage/timeout → bare name; the listing never fails
- Output treated as untrusted: 4KB bounded read, control chars stripped, one line, 100-char cap (unit-tested)
- Runs only when **root** help renders (pre-parse detection incl. global flags) — no subprocess cost on ordinary commands; `tix repo --help` untouched; zero plugins → section omitted

Verified e2e with four fixture plugins: described, silent, hanging, and hostile (ANSI/BEL injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)