### PR TITLE
feat(cli): implement tix update self-updater

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,7 +53,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +64,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -68,10 +74,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -147,6 +180,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cookie"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,7 +279,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -176,6 +291,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -191,7 +315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -201,10 +325,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+ "zlib-rs",
+]
 
 [[package]]
 name = "foldhash"
@@ -289,6 +434,31 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "icu_collections"
@@ -497,6 +667,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,13 +694,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "once_cell"
@@ -576,6 +768,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -712,6 +910,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,7 +933,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -783,6 +1030,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +1054,12 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "smallvec"
@@ -814,6 +1078,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -849,6 +1119,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,7 +1145,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -897,6 +1178,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,15 +1225,21 @@ dependencies = [
  "clap",
  "clap_complete",
  "dirs",
+ "flate2",
+ "semver",
  "serde",
  "serde_json",
+ "sha2",
+ "tar",
  "tempfile",
  "tix-engine",
  "toml",
  "toml_edit",
  "tracing",
  "tracing-subscriber",
+ "ureq",
  "url",
+ "zip",
 ]
 
 [[package]]
@@ -1052,6 +1370,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,6 +1392,44 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+dependencies = [
+ "base64",
+ "cookie_store",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
 
 [[package]]
 name = "url"
@@ -1075,6 +1443,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -1099,6 +1473,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1159,10 +1539,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1172,6 +1570,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -1283,6 +1745,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,6 +1799,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,7 +1838,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/tix-cli/Cargo.toml
+++ b/tix-cli/Cargo.toml
@@ -11,14 +11,21 @@ path = "src/main.rs"
 clap = { version = "4.6.1", features = ["color", "derive"] }
 clap_complete = "4.6.9"
 dirs = "6.0.0"
+flate2 = "1.1.9"
+semver = "1.0.28"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
+sha2 = "0.11.0"
+tar = "0.4.46"
+tempfile = "3.27.0"
 tix-engine = { path = "../tix-engine" }
 toml = "1.1.2"
 toml_edit = { version = "0.25.13", features = ["serde"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+ureq = { version = "3.4.0", features = ["json"] }
 url = { version = "2.5.8", features = ["serde"] }
+zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/tix-cli/src/tix/cli/update.rs
+++ b/tix-cli/src/tix/cli/update.rs
@@ -1,11 +1,353 @@
+//! `tix update` — self-update from GitHub releases.
+//!
+//! Fetches the latest release, compares against the compiled-in version,
+//! and replaces the running binary via temp file + rename. A direct port of
+//! v2's self-updater, adjusted for the workspace and given `--dry-run` and
+//! checksum verification.
+
 use crate::tix::context::Context;
+use semver::Version;
+use serde::Deserialize;
+use sha2::Digest;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 use tix_engine::TixError;
-use clap;
+use tracing::{info, warn};
 
+/// GitHub repository the updater checks, overridable for testing.
+const DEFAULT_OWNER: &str = "armaan-v924";
+const DEFAULT_REPO: &str = "tix";
+const USER_AGENT: &str = concat!("tix-updater/", env!("CARGO_PKG_VERSION"));
+
+/// Arguments for `tix update`.
 #[derive(clap::Args, Debug)]
-pub struct Args {}
+pub struct Args {
+    /// Print what would happen without downloading or writing anything
+    #[arg(long)]
+    pub dry_run: bool,
+}
 
+#[derive(Debug, Deserialize)]
+struct ReleaseAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Release {
+    tag_name: String,
+    assets: Vec<ReleaseAsset>,
+}
+
+/// The platform triple's slice of a release: asset naming + binary name.
+struct Target {
+    asset_suffix: &'static str,
+    archive_ext: &'static str,
+    exe_name: &'static str,
+}
+
+/// Checks the latest GitHub release and installs it when newer.
+///
+/// Asset naming follows the release workflow's convention:
+/// `tix-v<version>-<os>-<arch>.<tar.gz|zip>`. If the release also carries a
+/// `<asset>.sha256` sibling, the download is verified against it; releases
+/// without checksums skip verification. The binary is replaced via temp
+/// file + rename in its own directory.
 pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
-    println!("{:#?}", args);
+    let target = detect_target()?;
+    let owner = std::env::var("TIX_UPDATE_OWNER").unwrap_or_else(|_| DEFAULT_OWNER.into());
+    let repo = std::env::var("TIX_UPDATE_REPO").unwrap_or_else(|_| DEFAULT_REPO.into());
+
+    let release = fetch_latest_release(&owner, &repo)?;
+    let latest = parse_tag(&release.tag_name)?;
+    let current = Version::parse(env!("CARGO_PKG_VERSION"))
+        .map_err(|e| TixError::Message(format!("could not parse own version: {e}")))?;
+
+    if latest <= current {
+        println!("tix {current} is already up to date (latest release: {latest})");
+        return Ok(());
+    }
+
+    let asset_name = format!(
+        "tix-v{latest}-{}.{}",
+        target.asset_suffix, target.archive_ext
+    );
+    let asset = release
+        .assets
+        .iter()
+        .find(|asset| asset.name == asset_name)
+        .ok_or_else(|| {
+            TixError::Message(format!(
+                "release {} has no asset '{asset_name}' for this platform",
+                release.tag_name
+            ))
+        })?;
+    let checksum_asset = release
+        .assets
+        .iter()
+        .find(|a| a.name == format!("{asset_name}.sha256"));
+    let destination = install_destination(&target)?;
+
+    if args.dry_run {
+        println!("would update tix {current} -> {latest}");
+        println!("  asset:       {asset_name}");
+        println!(
+            "  checksum:    {}",
+            checksum_asset.map_or("none published", |_| "verified against .sha256")
+        );
+        println!("  destination: {}", destination.display());
+        return Ok(());
+    }
+
+    info!(from = %current, to = %latest, asset = %asset_name, "updating tix");
+    let staging = tempfile::tempdir().map_err(TixError::IoError)?;
+    let archive_path = staging.path().join(&asset.name);
+    download(&asset.browser_download_url, &archive_path)?;
+
+    if let Some(checksum) = checksum_asset {
+        verify_checksum(&archive_path, &checksum.browser_download_url)?;
+    } else {
+        info!("release publishes no checksum for '{asset_name}' — skipping verification");
+    }
+
+    let extracted = extract_archive(&archive_path, &target)?;
+    install_binary(&extracted, &destination)?;
+
+    println!("updated tix {current} -> {latest} ({})", destination.display());
+    Ok(())
+}
+
+fn fetch_latest_release(owner: &str, repo: &str) -> Result<Release, TixError> {
+    let url = format!("https://api.github.com/repos/{owner}/{repo}/releases/latest");
+    let mut response = ureq::get(&url)
+        .header("User-Agent", USER_AGENT)
+        .call()
+        .map_err(|e| TixError::Message(format!("could not fetch latest release: {e}")))?;
+    response
+        .body_mut()
+        .read_json::<Release>()
+        .map_err(|e| TixError::Message(format!("could not parse release JSON: {e}")))
+}
+
+fn parse_tag(tag: &str) -> Result<Version, TixError> {
+    Version::parse(tag.trim_start_matches('v'))
+        .map_err(|e| TixError::Message(format!("invalid release tag '{tag}': {e}")))
+}
+
+fn detect_target() -> Result<Target, TixError> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("linux", "x86_64") => Ok(Target {
+            asset_suffix: "linux-x86_64",
+            archive_ext: "tar.gz",
+            exe_name: "tix",
+        }),
+        ("macos", "aarch64") => Ok(Target {
+            asset_suffix: "macos-aarch64",
+            archive_ext: "tar.gz",
+            exe_name: "tix",
+        }),
+        ("windows", "x86_64") => Ok(Target {
+            asset_suffix: "windows-x86_64",
+            archive_ext: "zip",
+            exe_name: "tix.exe",
+        }),
+        (os, arch) => Err(TixError::Message(format!(
+            "self-update is not supported on {os}-{arch}"
+        ))),
+    }
+}
+
+fn download(url: &str, dest: &Path) -> Result<(), TixError> {
+    let mut response = ureq::get(url)
+        .header("User-Agent", USER_AGENT)
+        .call()
+        .map_err(|e| TixError::Message(format!("download failed: {e}")))?;
+    let mut file = std::fs::File::create(dest).map_err(TixError::IoError)?;
+    std::io::copy(&mut response.body_mut().as_reader(), &mut file).map_err(TixError::IoError)?;
+    Ok(())
+}
+
+/// Verifies the downloaded archive against the release's `.sha256` asset
+/// (`<hex digest>` optionally followed by a filename, sha256sum-style).
+fn verify_checksum(archive_path: &Path, checksum_url: &str) -> Result<(), TixError> {
+    let mut response = ureq::get(checksum_url)
+        .header("User-Agent", USER_AGENT)
+        .call()
+        .map_err(|e| TixError::Message(format!("checksum download failed: {e}")))?;
+    let mut text = String::new();
+    response
+        .body_mut()
+        .as_reader()
+        .take(4096)
+        .read_to_string(&mut text)
+        .map_err(TixError::IoError)?;
+    let expected = text
+        .split_whitespace()
+        .next()
+        .ok_or_else(|| TixError::Message("empty checksum file".to_string()))?
+        .to_lowercase();
+
+    let bytes = std::fs::read(archive_path).map_err(TixError::IoError)?;
+    let actual = hex(&sha2::Sha256::digest(&bytes));
+    if actual != expected {
+        return Err(TixError::Message(format!(
+            "checksum mismatch: expected {expected}, got {actual} — not installing"
+        )));
+    }
+    info!("checksum verified");
+    Ok(())
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Pulls the target executable out of the archive into its parent dir.
+fn extract_archive(archive_path: &Path, target: &Target) -> Result<PathBuf, TixError> {
+    let out_dir = archive_path
+        .parent()
+        .expect("staging archive always has a parent")
+        .join("extract");
+    std::fs::create_dir_all(&out_dir).map_err(TixError::IoError)?;
+
+    match target.archive_ext {
+        "tar.gz" => extract_tar_gz(archive_path, &out_dir, target.exe_name),
+        "zip" => extract_zip(archive_path, &out_dir, target.exe_name),
+        other => Err(TixError::Message(format!(
+            "unsupported archive format '{other}'"
+        ))),
+    }
+}
+
+fn extract_tar_gz(archive_path: &Path, out_dir: &Path, exe: &str) -> Result<PathBuf, TixError> {
+    let file = std::fs::File::open(archive_path).map_err(TixError::IoError)?;
+    let mut archive = tar::Archive::new(flate2::read::GzDecoder::new(file));
+    for entry in archive.entries().map_err(TixError::IoError)? {
+        let mut entry = entry.map_err(TixError::IoError)?;
+        let is_exe = entry
+            .path()
+            .map_err(TixError::IoError)?
+            .file_name()
+            .is_some_and(|name| name == exe);
+        if is_exe {
+            let dest = out_dir.join(exe);
+            entry.unpack(&dest).map_err(TixError::IoError)?;
+            return Ok(dest);
+        }
+    }
+    Err(TixError::Message(format!(
+        "executable '{exe}' not found in archive"
+    )))
+}
+
+fn extract_zip(archive_path: &Path, out_dir: &Path, exe: &str) -> Result<PathBuf, TixError> {
+    let file = std::fs::File::open(archive_path).map_err(TixError::IoError)?;
+    let mut archive = zip::ZipArchive::new(file)
+        .map_err(|e| TixError::Message(format!("could not read zip archive: {e}")))?;
+    for index in 0..archive.len() {
+        let mut entry = archive
+            .by_index(index)
+            .map_err(|e| TixError::Message(format!("could not read zip entry: {e}")))?;
+        let is_exe = Path::new(entry.name())
+            .file_name()
+            .is_some_and(|name| name == exe);
+        if is_exe {
+            let dest = out_dir.join(exe);
+            let mut out = std::fs::File::create(&dest).map_err(TixError::IoError)?;
+            std::io::copy(&mut entry, &mut out).map_err(TixError::IoError)?;
+            return Ok(dest);
+        }
+    }
+    Err(TixError::Message(format!(
+        "executable '{exe}' not found in archive"
+    )))
+}
+
+/// Where the new binary lands: `TIX_INSTALL_PATH` override, else next to the
+/// currently running executable.
+fn install_destination(target: &Target) -> Result<PathBuf, TixError> {
+    if let Ok(path) = std::env::var("TIX_INSTALL_PATH") {
+        return Ok(PathBuf::from(path));
+    }
+    let current = std::env::current_exe().map_err(TixError::IoError)?;
+    let parent = current
+        .parent()
+        .ok_or_else(|| TixError::Message("running executable has no parent directory".into()))?;
+    Ok(parent.join(target.exe_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A release-shaped tar.gz (./LICENSE, ./tix) extracts the executable,
+    /// and install_binary lands it at the destination with the exec bit.
+    #[test]
+    fn test_extract_and_install() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive_path = dir.path().join("tix-v9.9.9-macos-aarch64.tar.gz");
+        let gz = flate2::write::GzEncoder::new(
+            std::fs::File::create(&archive_path).unwrap(),
+            flate2::Compression::default(),
+        );
+        let mut builder = tar::Builder::new(gz);
+        for (name, contents) in [("./LICENSE", "MIT"), ("./tix", "#!/bin/sh\necho new\n")] {
+            let mut header = tar::Header::new_gnu();
+            header.set_path(name).unwrap();
+            header.set_size(contents.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder.append(&header, contents.as_bytes()).unwrap();
+        }
+        builder.into_inner().unwrap().finish().unwrap();
+
+        let target = Target {
+            asset_suffix: "macos-aarch64",
+            archive_ext: "tar.gz",
+            exe_name: "tix",
+        };
+        let extracted = extract_archive(&archive_path, &target).unwrap();
+        assert!(extracted.ends_with("tix"));
+
+        let dest = dir.path().join("bin/tix");
+        install_binary(&extracted, &dest).unwrap();
+        assert_eq!(std::fs::read_to_string(&dest).unwrap(), "#!/bin/sh\necho new\n");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_ne!(dest.metadata().unwrap().permissions().mode() & 0o111, 0);
+        }
+    }
+
+    /// A checksum mismatch refuses to install.
+    #[test]
+    fn test_hex_digest() {
+        // sha256("") — the well-known empty digest.
+        assert_eq!(
+            hex(&sha2::Sha256::digest(b"")),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+}
+
+/// Replaces the binary: rename when possible (same filesystem — atomic),
+/// copy as the cross-device fallback; executable bit restored on unix.
+fn install_binary(src: &Path, dest: &Path) -> Result<(), TixError> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(TixError::IoError)?;
+    }
+    if dest.exists() {
+        warn!(dest = %dest.display(), "replacing existing binary");
+    }
+    std::fs::rename(src, dest).or_else(|_| {
+        std::fs::copy(src, dest).map(|_| ()).map_err(TixError::IoError)
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dest, std::fs::Permissions::from_mode(0o755))
+            .map_err(TixError::IoError)?;
+    }
     Ok(())
 }


### PR DESCRIPTION
Closes #84

Stacked on #124 (base: `armaan/help-plugins-70`).

- Latest-release fetch (`ureq` + `json` feature), semver compare vs `CARGO_PKG_VERSION`, platform asset per the existing `build-release.yml` naming (`linux-x86_64`/`macos-aarch64` tar.gz, `windows-x86_64` zip)
- Temp-dir staging → extract just the executable → rename into place (copy fallback), exec bit restored; `TIX_INSTALL_PATH`/`TIX_UPDATE_OWNER`/`TIX_UPDATE_REPO` overrides kept from the v2 implementation this ports
- `--dry-run` prints version delta / asset / checksum availability / destination
- `.sha256` sibling asset verified when published; skipped (with a log) otherwise — current releases publish none
- Extraction + install covered by unit test (release-shaped tarball fixture); live check verified: `tix update` against the real API reports "already up to date" and exits 0
- Dep note: `zip` without default features and `time` pinned 0.3.47 — `time 0.3.55` is currently a broken publish (requires an unpublished `time-macros`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)