### PR TITLE
feat(sdk)!: create tix-sdk — promote context layer, add invocation contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,7 +1232,7 @@ dependencies = [
  "sha2",
  "tar",
  "tempfile",
- "tix-engine",
+ "tix-sdk",
  "toml",
  "toml_edit",
  "tracing",
@@ -1246,11 +1246,23 @@ dependencies = [
 name = "tix-engine"
 version = "3.0.0"
 dependencies = [
- "dirs",
  "git2",
  "serde",
  "tempfile",
  "toml",
+ "tracing",
+]
+
+[[package]]
+name = "tix-sdk"
+version = "3.0.0"
+dependencies = [
+ "dirs",
+ "serde",
+ "tempfile",
+ "tix-engine",
+ "toml",
+ "toml_edit",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,13 @@
 [workspace]
 members = [
     "tix-engine",
+    "tix-sdk",
     "tix-cli",
     "pytix",
 ]
 default-members = [
     "tix-engine",
+    "tix-sdk",
     "tix-cli",
 ]
 resolver = "2"

--- a/tix-cli/Cargo.toml
+++ b/tix-cli/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = "1.0.151"
 sha2 = "0.11.0"
 tar = "0.4.46"
 tempfile = "3.27.0"
-tix-engine = { path = "../tix-engine" }
+tix-sdk = { path = "../tix-sdk" }
 toml = "1.1.2"
 toml_edit = { version = "0.25.13", features = ["serde"] }
 tracing = "0.1.44"

--- a/tix-cli/src/main.rs
+++ b/tix-cli/src/main.rs
@@ -1,15 +1,14 @@
 mod tix;
 
-use crate::tix::context::Context;
+use tix_sdk::context::Context;
 use crate::tix::{Commands, cli, config, plugin, repo, ticket};
-use clap::Parser;
 use tracing_subscriber::fmt;
 
 /// Prints a CLI error to stderr and exits nonzero.
 ///
 /// The frontend owns process control and user-facing output — the engine
 /// only ever returns errors.
-fn fail(error: tix_engine::TixError) -> ! {
+fn fail(error: tix_sdk::SdkError) -> ! {
     eprintln!("error: {error}");
     std::process::exit(1);
 }

--- a/tix-cli/src/tix/cli/completions.rs
+++ b/tix-cli/src/tix/cli/completions.rs
@@ -3,9 +3,9 @@
 //! Third-party plugin completions are not tix's problem: plugins are external
 //! binaries with their own interfaces.
 
-use crate::tix::context::Context;
+use tix_sdk::context::Context;
 use clap::CommandFactory;
-use tix_engine::TixError;
+use tix_sdk::SdkError;
 
 /// Arguments for `tix completions`.
 #[derive(clap::Args, Debug)]
@@ -25,7 +25,7 @@ pub struct Args {
 
 /// Generates completions from the clap command definition onto stdout — the
 /// user pipes them into their shell's completion path (see `--help`).
-pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
+pub fn run(_context: &Context, args: Args) -> Result<(), SdkError> {
     let mut command = crate::tix::TixParser::command();
     clap_complete::generate(
         args.shell,

--- a/tix-cli/src/tix/cli/update.rs
+++ b/tix-cli/src/tix/cli/update.rs
@@ -5,13 +5,13 @@
 //! v2's self-updater, adjusted for the workspace and given `--dry-run` and
 //! checksum verification.
 
-use crate::tix::context::Context;
+use tix_sdk::context::Context;
 use semver::Version;
 use serde::Deserialize;
 use sha2::Digest;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use tix_engine::TixError;
+use tix_sdk::SdkError;
 use tracing::{info, warn};
 
 /// GitHub repository the updater checks, overridable for testing.
@@ -53,7 +53,7 @@ struct Target {
 /// `<asset>.sha256` sibling, the download is verified against it; releases
 /// without checksums skip verification. The binary is replaced via temp
 /// file + rename in its own directory.
-pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
+pub fn run(_context: &Context, args: Args) -> Result<(), SdkError> {
     let target = detect_target()?;
     let owner = std::env::var("TIX_UPDATE_OWNER").unwrap_or_else(|_| DEFAULT_OWNER.into());
     let repo = std::env::var("TIX_UPDATE_REPO").unwrap_or_else(|_| DEFAULT_REPO.into());
@@ -61,7 +61,7 @@ pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
     let release = fetch_latest_release(&owner, &repo)?;
     let latest = parse_tag(&release.tag_name)?;
     let current = Version::parse(env!("CARGO_PKG_VERSION"))
-        .map_err(|e| TixError::Message(format!("could not parse own version: {e}")))?;
+        .map_err(|e| SdkError::Message(format!("could not parse own version: {e}")))?;
 
     if latest <= current {
         println!("tix {current} is already up to date (latest release: {latest})");
@@ -77,7 +77,7 @@ pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
         .iter()
         .find(|asset| asset.name == asset_name)
         .ok_or_else(|| {
-            TixError::Message(format!(
+            SdkError::Message(format!(
                 "release {} has no asset '{asset_name}' for this platform",
                 release.tag_name
             ))
@@ -100,7 +100,7 @@ pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
     }
 
     info!(from = %current, to = %latest, asset = %asset_name, "updating tix");
-    let staging = tempfile::tempdir().map_err(TixError::IoError)?;
+    let staging = tempfile::tempdir().map_err(SdkError::from)?;
     let archive_path = staging.path().join(&asset.name);
     download(&asset.browser_download_url, &archive_path)?;
 
@@ -117,24 +117,24 @@ pub fn run(_context: &Context, args: Args) -> Result<(), TixError> {
     Ok(())
 }
 
-fn fetch_latest_release(owner: &str, repo: &str) -> Result<Release, TixError> {
+fn fetch_latest_release(owner: &str, repo: &str) -> Result<Release, SdkError> {
     let url = format!("https://api.github.com/repos/{owner}/{repo}/releases/latest");
     let mut response = ureq::get(&url)
         .header("User-Agent", USER_AGENT)
         .call()
-        .map_err(|e| TixError::Message(format!("could not fetch latest release: {e}")))?;
+        .map_err(|e| SdkError::Message(format!("could not fetch latest release: {e}")))?;
     response
         .body_mut()
         .read_json::<Release>()
-        .map_err(|e| TixError::Message(format!("could not parse release JSON: {e}")))
+        .map_err(|e| SdkError::Message(format!("could not parse release JSON: {e}")))
 }
 
-fn parse_tag(tag: &str) -> Result<Version, TixError> {
+fn parse_tag(tag: &str) -> Result<Version, SdkError> {
     Version::parse(tag.trim_start_matches('v'))
-        .map_err(|e| TixError::Message(format!("invalid release tag '{tag}': {e}")))
+        .map_err(|e| SdkError::Message(format!("invalid release tag '{tag}': {e}")))
 }
 
-fn detect_target() -> Result<Target, TixError> {
+fn detect_target() -> Result<Target, SdkError> {
     match (std::env::consts::OS, std::env::consts::ARCH) {
         ("linux", "x86_64") => Ok(Target {
             asset_suffix: "linux-x86_64",
@@ -151,46 +151,46 @@ fn detect_target() -> Result<Target, TixError> {
             archive_ext: "zip",
             exe_name: "tix.exe",
         }),
-        (os, arch) => Err(TixError::Message(format!(
+        (os, arch) => Err(SdkError::Message(format!(
             "self-update is not supported on {os}-{arch}"
         ))),
     }
 }
 
-fn download(url: &str, dest: &Path) -> Result<(), TixError> {
+fn download(url: &str, dest: &Path) -> Result<(), SdkError> {
     let mut response = ureq::get(url)
         .header("User-Agent", USER_AGENT)
         .call()
-        .map_err(|e| TixError::Message(format!("download failed: {e}")))?;
-    let mut file = std::fs::File::create(dest).map_err(TixError::IoError)?;
-    std::io::copy(&mut response.body_mut().as_reader(), &mut file).map_err(TixError::IoError)?;
+        .map_err(|e| SdkError::Message(format!("download failed: {e}")))?;
+    let mut file = std::fs::File::create(dest).map_err(SdkError::from)?;
+    std::io::copy(&mut response.body_mut().as_reader(), &mut file).map_err(SdkError::from)?;
     Ok(())
 }
 
 /// Verifies the downloaded archive against the release's `.sha256` asset
 /// (`<hex digest>` optionally followed by a filename, sha256sum-style).
-fn verify_checksum(archive_path: &Path, checksum_url: &str) -> Result<(), TixError> {
+fn verify_checksum(archive_path: &Path, checksum_url: &str) -> Result<(), SdkError> {
     let mut response = ureq::get(checksum_url)
         .header("User-Agent", USER_AGENT)
         .call()
-        .map_err(|e| TixError::Message(format!("checksum download failed: {e}")))?;
+        .map_err(|e| SdkError::Message(format!("checksum download failed: {e}")))?;
     let mut text = String::new();
     response
         .body_mut()
         .as_reader()
         .take(4096)
         .read_to_string(&mut text)
-        .map_err(TixError::IoError)?;
+        .map_err(SdkError::from)?;
     let expected = text
         .split_whitespace()
         .next()
-        .ok_or_else(|| TixError::Message("empty checksum file".to_string()))?
+        .ok_or_else(|| SdkError::Message("empty checksum file".to_string()))?
         .to_lowercase();
 
-    let bytes = std::fs::read(archive_path).map_err(TixError::IoError)?;
+    let bytes = std::fs::read(archive_path).map_err(SdkError::from)?;
     let actual = hex(&sha2::Sha256::digest(&bytes));
     if actual != expected {
-        return Err(TixError::Message(format!(
+        return Err(SdkError::Message(format!(
             "checksum mismatch: expected {expected}, got {actual} — not installing"
         )));
     }
@@ -203,76 +203,76 @@ fn hex(bytes: &[u8]) -> String {
 }
 
 /// Pulls the target executable out of the archive into its parent dir.
-fn extract_archive(archive_path: &Path, target: &Target) -> Result<PathBuf, TixError> {
+fn extract_archive(archive_path: &Path, target: &Target) -> Result<PathBuf, SdkError> {
     let out_dir = archive_path
         .parent()
         .expect("staging archive always has a parent")
         .join("extract");
-    std::fs::create_dir_all(&out_dir).map_err(TixError::IoError)?;
+    std::fs::create_dir_all(&out_dir).map_err(SdkError::from)?;
 
     match target.archive_ext {
         "tar.gz" => extract_tar_gz(archive_path, &out_dir, target.exe_name),
         "zip" => extract_zip(archive_path, &out_dir, target.exe_name),
-        other => Err(TixError::Message(format!(
+        other => Err(SdkError::Message(format!(
             "unsupported archive format '{other}'"
         ))),
     }
 }
 
-fn extract_tar_gz(archive_path: &Path, out_dir: &Path, exe: &str) -> Result<PathBuf, TixError> {
-    let file = std::fs::File::open(archive_path).map_err(TixError::IoError)?;
+fn extract_tar_gz(archive_path: &Path, out_dir: &Path, exe: &str) -> Result<PathBuf, SdkError> {
+    let file = std::fs::File::open(archive_path).map_err(SdkError::from)?;
     let mut archive = tar::Archive::new(flate2::read::GzDecoder::new(file));
-    for entry in archive.entries().map_err(TixError::IoError)? {
-        let mut entry = entry.map_err(TixError::IoError)?;
+    for entry in archive.entries().map_err(SdkError::from)? {
+        let mut entry = entry.map_err(SdkError::from)?;
         let is_exe = entry
             .path()
-            .map_err(TixError::IoError)?
+            .map_err(SdkError::from)?
             .file_name()
             .is_some_and(|name| name == exe);
         if is_exe {
             let dest = out_dir.join(exe);
-            entry.unpack(&dest).map_err(TixError::IoError)?;
+            entry.unpack(&dest).map_err(SdkError::from)?;
             return Ok(dest);
         }
     }
-    Err(TixError::Message(format!(
+    Err(SdkError::Message(format!(
         "executable '{exe}' not found in archive"
     )))
 }
 
-fn extract_zip(archive_path: &Path, out_dir: &Path, exe: &str) -> Result<PathBuf, TixError> {
-    let file = std::fs::File::open(archive_path).map_err(TixError::IoError)?;
+fn extract_zip(archive_path: &Path, out_dir: &Path, exe: &str) -> Result<PathBuf, SdkError> {
+    let file = std::fs::File::open(archive_path).map_err(SdkError::from)?;
     let mut archive = zip::ZipArchive::new(file)
-        .map_err(|e| TixError::Message(format!("could not read zip archive: {e}")))?;
+        .map_err(|e| SdkError::Message(format!("could not read zip archive: {e}")))?;
     for index in 0..archive.len() {
         let mut entry = archive
             .by_index(index)
-            .map_err(|e| TixError::Message(format!("could not read zip entry: {e}")))?;
+            .map_err(|e| SdkError::Message(format!("could not read zip entry: {e}")))?;
         let is_exe = Path::new(entry.name())
             .file_name()
             .is_some_and(|name| name == exe);
         if is_exe {
             let dest = out_dir.join(exe);
-            let mut out = std::fs::File::create(&dest).map_err(TixError::IoError)?;
-            std::io::copy(&mut entry, &mut out).map_err(TixError::IoError)?;
+            let mut out = std::fs::File::create(&dest).map_err(SdkError::from)?;
+            std::io::copy(&mut entry, &mut out).map_err(SdkError::from)?;
             return Ok(dest);
         }
     }
-    Err(TixError::Message(format!(
+    Err(SdkError::Message(format!(
         "executable '{exe}' not found in archive"
     )))
 }
 
 /// Where the new binary lands: `TIX_INSTALL_PATH` override, else next to the
 /// currently running executable.
-fn install_destination(target: &Target) -> Result<PathBuf, TixError> {
+fn install_destination(target: &Target) -> Result<PathBuf, SdkError> {
     if let Ok(path) = std::env::var("TIX_INSTALL_PATH") {
         return Ok(PathBuf::from(path));
     }
-    let current = std::env::current_exe().map_err(TixError::IoError)?;
+    let current = std::env::current_exe().map_err(SdkError::from)?;
     let parent = current
         .parent()
-        .ok_or_else(|| TixError::Message("running executable has no parent directory".into()))?;
+        .ok_or_else(|| SdkError::Message("running executable has no parent directory".into()))?;
     Ok(parent.join(target.exe_name))
 }
 
@@ -332,22 +332,22 @@ mod tests {
 
 /// Replaces the binary: rename when possible (same filesystem — atomic),
 /// copy as the cross-device fallback; executable bit restored on unix.
-fn install_binary(src: &Path, dest: &Path) -> Result<(), TixError> {
+fn install_binary(src: &Path, dest: &Path) -> Result<(), SdkError> {
     if let Some(parent) = dest.parent() {
-        std::fs::create_dir_all(parent).map_err(TixError::IoError)?;
+        std::fs::create_dir_all(parent).map_err(SdkError::from)?;
     }
     if dest.exists() {
         warn!(dest = %dest.display(), "replacing existing binary");
     }
     std::fs::rename(src, dest).or_else(|_| {
-        std::fs::copy(src, dest).map(|_| ()).map_err(TixError::IoError)
+        std::fs::copy(src, dest).map(|_| ()).map_err(SdkError::from)
     })?;
 
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(dest, std::fs::Permissions::from_mode(0o755))
-            .map_err(TixError::IoError)?;
+            .map_err(SdkError::from)?;
     }
     Ok(())
 }

--- a/tix-cli/src/tix/config/get.rs
+++ b/tix-cli/src/tix/config/get.rs
@@ -1,10 +1,10 @@
 //! `tix config get` — read value(s) from the `[cli]` section.
 
 use crate::tix::config::ConfigKey;
-use crate::tix::context::Context;
-use crate::tix::document::TixDocument;
+use tix_sdk::context::Context;
+use tix_sdk::document::TixDocument;
 use crate::tix::utils::OutputType;
-use tix_engine::TixError;
+use tix_sdk::SdkError;
 
 /// Arguments for `tix config get`.
 #[derive(clap::Args, Debug)]
@@ -24,7 +24,7 @@ pub struct Args {
 /// print `key = value` lines. Keys are validated at parse time by the
 /// [`ConfigKey`] value enum; a key that is valid but unset in the document
 /// errors here.
-pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
     let document = TixDocument::load(&context.config_path)?;
 
     let mut pairs = Vec::with_capacity(args.key.len());
@@ -34,7 +34,7 @@ pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
             .get("cli")
             .and_then(|cli| cli.get(key.toml_key()))
             .ok_or_else(|| {
-                TixError::Message(format!(
+                SdkError::Message(format!(
                     "'{}' is not set in [cli] (config: {})",
                     key.toml_key(),
                     context.config_path.display()
@@ -79,8 +79,8 @@ fn render_bare(item: &toml_edit::Item) -> String {
 
 /// Converts one TOML item to JSON by round-tripping it through a real TOML
 /// parse — handles every value shape without a hand-written mapping.
-fn item_to_json(key: &str, item: &toml_edit::Item) -> Result<serde_json::Value, TixError> {
+fn item_to_json(key: &str, item: &toml_edit::Item) -> Result<serde_json::Value, SdkError> {
     let table: toml::Table = toml::from_str(&format!("{key} = {}", item.to_string().trim()))?;
     let value = table.get(key).cloned().unwrap_or(toml::Value::String(String::new()));
-    serde_json::to_value(value).map_err(|e| TixError::Message(format!("json conversion failed: {e}")))
+    serde_json::to_value(value).map_err(|e| SdkError::Message(format!("json conversion failed: {e}")))
 }

--- a/tix-cli/src/tix/config/init.rs
+++ b/tix-cli/src/tix/config/init.rs
@@ -1,9 +1,9 @@
 //! `tix config init` — interactive first-time config creation.
 
-use crate::tix::context::Context;
-use crate::tix::document::TixDocument;
+use tix_sdk::context::Context;
+use tix_sdk::document::TixDocument;
 use crate::tix::utils::prompt;
-use tix_engine::TixError;
+use tix_sdk::SdkError;
 
 /// Arguments for `tix config init`.
 #[derive(clap::Args, Debug)]
@@ -20,10 +20,10 @@ pub struct Args {
 /// uses (`--config` > `TIX_CONFIG_PATH` > platform default), which is why
 /// this command is exempt from the config-must-exist check. Parent
 /// directories are created; an existing file is refused without `--force`.
-pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
     let path = &context.config_path;
     if path.exists() && !args.force {
-        return Err(TixError::Message(format!(
+        return Err(SdkError::Message(format!(
             "config already exists at {} — pass --force to overwrite",
             path.display()
         )));

--- a/tix-cli/src/tix/config/mod.rs
+++ b/tix-cli/src/tix/config/mod.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 /// Owned by the frontend, not the engine (`design/spec.md` §3.2): directory
 /// layout is frontend policy, and the engine has no `tickets_directory`.
 /// Extracted from the parsed document via the section accessors
-/// ([`crate::tix::document::TixDocument::section`]).
+/// ([`tix_sdk::document::TixDocument::section`]).
 ///
 /// # Examples
 ///

--- a/tix-cli/src/tix/config/set.rs
+++ b/tix-cli/src/tix/config/set.rs
@@ -2,9 +2,9 @@
 //! document layer.
 
 use crate::tix::config::{CliConfig, ConfigKey};
-use crate::tix::context::Context;
-use crate::tix::document::with_write;
-use tix_engine::TixError;
+use tix_sdk::context::Context;
+use tix_sdk::document::with_write;
+use tix_sdk::SdkError;
 
 /// Arguments for `tix config set`.
 #[derive(clap::Args, Debug)]
@@ -27,7 +27,7 @@ pub struct Args {
 ///
 /// The whole cycle runs under the exclusive advisory lock (#67), so
 /// concurrent `tix config set` invocations serialize rather than clobber.
-pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
     with_write(&context.config_path, |document| {
         // `1` stays an integer, `true` a bool; anything that isn't valid
         // TOML (a bare path, say) is a string.
@@ -45,7 +45,7 @@ pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
         // Revalidate: the edited section must still parse as CliConfig
         // (deny_unknown_fields; type-incompatible values fail here).
         let _valid: CliConfig = document.section("cli")?.ok_or_else(|| {
-            TixError::Message("edit produced no [cli] section — this is a bug".to_string())
+            SdkError::Message("edit produced no [cli] section — this is a bug".to_string())
         })?;
         Ok(())
     })?;

--- a/tix-cli/src/tix/config/show.rs
+++ b/tix-cli/src/tix/config/show.rs
@@ -1,9 +1,9 @@
 //! `tix config show` — print the whole global config document.
 
-use crate::tix::context::Context;
-use crate::tix::document::TixDocument;
+use tix_sdk::context::Context;
+use tix_sdk::document::TixDocument;
 use crate::tix::utils::OutputType;
-use tix_engine::TixError;
+use tix_sdk::SdkError;
 
 /// Arguments for `tix config show`.
 #[derive(clap::Args, Debug)]
@@ -19,14 +19,14 @@ pub struct Args {
 /// comments, formatting, and plugin tables preserved, straight from the
 /// format-preserving DOM. JSON output converts the document's *values*
 /// (comments cannot survive a format that has none).
-pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
     let document = TixDocument::load(&context.config_path)?;
     match args.output.unwrap_or(OutputType::Default) {
         OutputType::Default | OutputType::Toml => print!("{document}"),
         OutputType::Json => {
             let value: toml::Value = toml::from_str(&document.to_string())?;
             let json = serde_json::to_string_pretty(&value)
-                .map_err(|e| TixError::Message(format!("json conversion failed: {e}")))?;
+                .map_err(|e| SdkError::Message(format!("json conversion failed: {e}")))?;
             println!("{json}");
         }
     }

--- a/tix-cli/src/tix/mod.rs
+++ b/tix-cli/src/tix/mod.rs
@@ -3,9 +3,6 @@ pub mod config;
 pub mod repo;
 pub mod ticket;
 
-pub mod context;
-pub mod discovery;
-pub mod document;
 pub mod plugin;
 pub mod plugin_listing;
 pub mod utils;

--- a/tix-cli/src/tix/plugin.rs
+++ b/tix-cli/src/tix/plugin.rs
@@ -1,7 +1,7 @@
-use crate::tix::context::Context;
-use tix_engine::TixError;
+use tix_sdk::context::Context;
+use tix_sdk::SdkError;
 
-pub fn run(_context: &Context, args: Vec<String>) -> Result<(), TixError> {
+pub fn run(_context: &Context, args: Vec<String>) -> Result<(), SdkError> {
     println!("{:#?}", args);
     Ok(())
 }

--- a/tix-cli/src/tix/repo/add.rs
+++ b/tix-cli/src/tix/repo/add.rs
@@ -2,11 +2,11 @@
 //! `tix repo clone` (#65).
 
 use crate::tix::config::CliConfig;
-use crate::tix::context::Context;
-use crate::tix::document::with_write;
+use tix_sdk::context::Context;
+use tix_sdk::document::with_write;
 use crate::tix::repo::{RepoAlias, RepoRef};
 use crate::tix::ticket::load_cli_config;
-use tix_engine::{Defaults, EngineConfig, TixError};
+use tix_sdk::{Defaults, EngineConfig, SdkError};
 
 /// Arguments for `tix repo add`.
 #[derive(clap::Args, Debug)]
@@ -37,7 +37,7 @@ pub struct Args {
 /// `code_path` derives as `<code_directory>/<alias>`. The write goes through
 /// the format-preserving layer and revalidates `EngineConfig` before landing;
 /// re-adding an existing alias errors.
-pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
     let cli: CliConfig = load_cli_config(context)?;
 
     // Alias may come from the flag; otherwise it falls out of the parse.
@@ -52,7 +52,7 @@ pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
     with_write(&context.config_path, |document| {
         let existing: EngineConfig = document.section_or_default("engine")?;
         if existing.configured_repositories.contains_key(&alias) {
-            return Err(TixError::Message(format!(
+            return Err(SdkError::Message(format!(
                 "alias '{alias}' is already registered (remote: {}) — pick another with --alias",
                 existing.configured_repositories[&alias].remote
             )));
@@ -78,7 +78,7 @@ fn resolve_remote(
     repo: &str,
     owner_flag: Option<&str>,
     context: &Context,
-) -> Result<(String, String), TixError> {
+) -> Result<(String, String), SdkError> {
     // Full URL forms pass through untouched.
     if repo.contains("://") || (repo.contains('@') && repo.contains(':')) {
         let name = repo
@@ -91,7 +91,7 @@ fn resolve_remote(
     }
 
     let defaults: Defaults =
-        crate::tix::document::TixDocument::load(&context.config_path)?.section_or_default("defaults")?;
+        tix_sdk::document::TixDocument::load(&context.config_path)?.section_or_default("defaults")?;
     let base = defaults
         .github_base_url
         .unwrap_or_else(|| "https://github.com".to_string());
@@ -104,14 +104,14 @@ fn resolve_remote(
                 .map(str::to_string)
                 .or(defaults.default_repository_owner)
                 .ok_or_else(|| {
-                    TixError::Message(format!(
+                    SdkError::Message(format!(
                         "'{name}' has no owner — pass --owner <owner> or set \
                          [defaults].default_repository_owner in config"
                     ))
                 })?;
             Ok((format!("{base}/{owner}/{name}.git"), (*name).to_string()))
         }
-        _ => Err(TixError::Message(format!(
+        _ => Err(SdkError::Message(format!(
             "'{repo}' is not a URL, owner/repo, or bare repo name"
         ))),
     }

--- a/tix-cli/src/tix/repo/clone.rs
+++ b/tix-cli/src/tix/repo/clone.rs
@@ -1,9 +1,9 @@
 //! `tix repo clone` — clone registered repositories to their code paths.
 
-use crate::tix::context::Context;
-use crate::tix::document::TixDocument;
+use tix_sdk::context::Context;
+use tix_sdk::document::TixDocument;
 use crate::tix::repo::RepoAlias;
-use tix_engine::{EngineConfig, TixError};
+use tix_sdk::{SdkError, EngineConfig, TixError};
 use tracing::error;
 
 /// Arguments for `tix repo clone`.
@@ -25,7 +25,7 @@ pub struct Args {
 /// The batch never aborts on one failure: every target is attempted, each
 /// outcome is reported on its own line, and the exit is nonzero if anything
 /// failed. Unknown aliases error up front listing the registered set.
-pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
     let document = TixDocument::load(&context.config_path)?;
     let engine: EngineConfig = document.section_or_default("engine")?;
 
@@ -41,11 +41,11 @@ pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
     } else {
         for alias in &args.repo_aliases {
             if !engine.configured_repositories.contains_key(&alias.0) {
-                return Err(TixError::RepoNotFound(format!(
+                return Err(SdkError::Engine(TixError::RepoNotFound(format!(
                     "'{}' is not a registered repository (registered: {})",
                     alias.0,
                     if registered.is_empty() { "none".to_string() } else { registered.join(", ") }
-                )));
+                ))));
             }
         }
         args.repo_aliases.iter().map(|alias| alias.0.clone()).collect()
@@ -67,7 +67,7 @@ pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
     }
 
     if failed > 0 {
-        return Err(TixError::Message(format!(
+        return Err(SdkError::Message(format!(
             "{failed} of {} clones failed",
             targets.len()
         )));

--- a/tix-cli/src/tix/ticket/add.rs
+++ b/tix-cli/src/tix/ticket/add.rs
@@ -1,12 +1,12 @@
 //! `tix ticket add` — add repository worktrees to an existing ticket.
 
-use crate::tix::context::Context;
-use crate::tix::document::{TixDocument, with_write};
+use tix_sdk::context::Context;
+use tix_sdk::document::{TixDocument, with_write};
 use crate::tix::repo::RepoAlias;
 use crate::tix::ticket::{
     TicketSharedArgs, derive_branch_name, load_ticket_config, require_ticket_root,
 };
-use tix_engine::{Defaults, EngineConfig, TixError};
+use tix_sdk::{SdkError, Defaults, EngineConfig, TixError};
 use tracing::{error, info};
 
 /// Arguments for `tix ticket add`.
@@ -38,7 +38,7 @@ pub struct Args {
 /// The ticket document is updated per successful worktree through the
 /// format-preserving layer, so plugin tables and comments in
 /// `.tix/ticket.toml` survive.
-pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
     let root = require_ticket_root(context, args.shared.ticket.as_ref())?;
     let ticket = load_ticket_config(&root)?;
 
@@ -56,14 +56,14 @@ pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
                 .map(String::as_str)
                 .collect();
             known.sort();
-            return Err(TixError::RepoNotFound(format!(
+            return Err(SdkError::Engine(TixError::RepoNotFound(format!(
                 "'{}' is not a registered repository (registered: {})",
                 alias.0,
                 if known.is_empty() { "none".to_string() } else { known.join(", ") }
-            )));
+            ))));
         }
         if ticket.worktrees.contains_key(&alias.0) {
-            return Err(TixError::Message(format!(
+            return Err(SdkError::Message(format!(
                 "ticket '{}' already has a worktree for '{}' — multiple worktrees of one repo is #85",
                 ticket.key, alias.0
             )));
@@ -111,7 +111,7 @@ pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
 
     if !failures.is_empty() {
         let names: Vec<&str> = failures.iter().map(|(alias, _)| alias.as_str()).collect();
-        return Err(TixError::Message(format!(
+        return Err(SdkError::Message(format!(
             "{} of {} worktrees failed: {}",
             failures.len(),
             args.repo_aliases.len(),

--- a/tix-cli/src/tix/ticket/destroy.rs
+++ b/tix-cli/src/tix/ticket/destroy.rs
@@ -1,9 +1,9 @@
 //! `tix ticket destroy` — prune every worktree, then delete the ticket.
 
-use crate::tix::context::Context;
-use crate::tix::document::{TixDocument, with_write};
+use tix_sdk::context::Context;
+use tix_sdk::document::{TixDocument, with_write};
 use crate::tix::ticket::{TicketRef, TicketSharedArgs, load_ticket_config, require_ticket_root};
-use tix_engine::{EngineConfig, TixError, WorktreeConfig};
+use tix_sdk::{SdkError, EngineConfig, TixError, WorktreeConfig};
 use tracing::{info, warn};
 
 /// Arguments for `tix ticket destroy`.
@@ -37,7 +37,7 @@ pub struct Args {
 /// fails** — forced deletion means deleted. Whatever had to be left behind
 /// (e.g. stale registrations in the source repos) is warned about, with a
 /// pointer at `git worktree prune`.
-pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
     let selector = args.target.as_ref().or(args.shared.ticket.as_ref());
     let root = require_ticket_root(context, selector)?;
     let ticket = load_ticket_config(&root)?;
@@ -94,7 +94,7 @@ pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
             }
             // The default path aborts before deleting anything further.
             (Err(e), false) => {
-                return Err(TixError::Message(format!(
+                return Err(SdkError::Message(format!(
                     "could not prune worktree '{}': {e} — nothing further was deleted; \
                      fix it (or pass --force) and retry",
                     name
@@ -103,7 +103,7 @@ pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
         }
     }
 
-    std::fs::remove_dir_all(&root).map_err(TixError::IoError)?;
+    std::fs::remove_dir_all(&root).map_err(SdkError::from)?;
     println!("destroyed {} ({})", ticket.key, root.display());
 
     if !leftovers.is_empty() {

--- a/tix-cli/src/tix/ticket/info.rs
+++ b/tix-cli/src/tix/ticket/info.rs
@@ -1,10 +1,10 @@
 //! `tix ticket info` — display a ticket's metadata and worktree table.
 
-use crate::tix::context::Context;
+use tix_sdk::context::Context;
 use crate::tix::ticket::{TicketSharedArgs, load_ticket_config, require_ticket_root};
 use crate::tix::utils::OutputType;
 use std::path::{Path, PathBuf};
-use tix_engine::{TicketConfig, TixError};
+use tix_sdk::{SdkError, TicketConfig};
 
 /// Arguments for `tix ticket info`.
 #[derive(clap::Args, Debug)]
@@ -37,7 +37,7 @@ impl WorktreeStatus {
     fn of(path: &Path) -> Self {
         if !path.is_dir() {
             WorktreeStatus::MissingDirectory
-        } else if !tix_engine::opens_as_git_repository(path) {
+        } else if !tix_sdk::opens_as_git_repository(path) {
             WorktreeStatus::NotAGitRepository
         } else {
             WorktreeStatus::Ok
@@ -70,7 +70,7 @@ impl WorktreeStatus {
 ///
 /// There is deliberately no single ticket branch to print: branches are
 /// per-worktree (spec §3.2).
-pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
     let root = require_ticket_root(context, args.shared.ticket.as_ref())?;
     let ticket: TicketConfig = load_ticket_config(&root)?;
 

--- a/tix-cli/src/tix/ticket/list.rs
+++ b/tix-cli/src/tix/ticket/list.rs
@@ -1,10 +1,10 @@
 //! `tix ticket list` — one line per ticket under the tickets directory.
 
-use crate::tix::context::Context;
-use crate::tix::document::TixDocument;
+use tix_sdk::context::Context;
+use tix_sdk::document::TixDocument;
 use crate::tix::ticket::load_cli_config;
 use crate::tix::utils::OutputType;
-use tix_engine::{TicketConfig, TixError};
+use tix_sdk::{SdkError, TicketConfig};
 use tracing::warn;
 
 /// Arguments for `tix ticket list`.
@@ -22,7 +22,7 @@ pub struct Args {
 /// layout is frontend policy; the engine is never involved). Directories
 /// without a `.tix/ticket.toml` are silently skipped; one with a malformed
 /// document warns and is skipped — a broken ticket never breaks the listing.
-pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
     let cli = load_cli_config(context)?;
 
     let mut tickets: Vec<TicketConfig> = Vec::new();
@@ -39,7 +39,7 @@ pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
         if !ticket_path.is_file() {
             continue;
         }
-        let parsed: Result<Option<TicketConfig>, TixError> =
+        let parsed: Result<Option<TicketConfig>, SdkError> =
             TixDocument::load(&ticket_path).and_then(|doc| doc.section("ticket"));
         match parsed {
             Ok(Some(ticket)) => tickets.push(ticket),
@@ -54,7 +54,7 @@ pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
 }
 
 /// Renders the listing in the requested format.
-fn print_tickets(tickets: &[TicketConfig], output: OutputType) -> Result<(), TixError> {
+fn print_tickets(tickets: &[TicketConfig], output: OutputType) -> Result<(), SdkError> {
     match output {
         OutputType::Default => {
             let width = tickets.iter().map(|t| t.key.len()).max().unwrap_or(0);

--- a/tix-cli/src/tix/ticket/mod.rs
+++ b/tix-cli/src/tix/ticket/mod.rs
@@ -8,70 +8,7 @@ pub mod setup;
 // ---
 
 use clap::{Args, Subcommand};
-use std::path::PathBuf;
-use std::str::FromStr;
-
-/// A `--ticket` argument: one flag, two forms, disambiguated by shape
-/// (`design/spec.md` §4).
-///
-/// - **Path** — the argument contains a path separator, is absolute, or is
-///   `.`/`..`. Asserts *this path is the ticket root*.
-/// - **Id** — any bare name, resolved against the configured tickets
-///   directory.
-///
-/// A bare name is always an id; a ticket directory in cwd must be written
-/// `./NAME`. See [`crate::tix::discovery::resolve_override`] for the
-/// resolution semantics.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum TicketRef {
-    /// An asserted ticket-root path (`./NAME`, `some/dir`, `/abs/path`, `.`, `..`).
-    Path(PathBuf),
-    /// A bare ticket id, resolved as `tickets_directory.join(id)`.
-    Id(String),
-}
-impl FromStr for TicketRef {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let path = std::path::Path::new(s);
-        let is_path_shape =
-            s == "." || s == ".." || path.is_absolute() || s.contains(['/', '\\']);
-        if is_path_shape {
-            Ok(TicketRef::Path(path.to_path_buf()))
-        } else {
-            Ok(TicketRef::Id(s.to_string()))
-        }
-    }
-}
-
-#[cfg(test)]
-mod ticket_ref_tests {
-    use super::*;
-
-    /// Absolute paths, `.`/`..`, and anything containing a separator parse as
-    /// the path form.
-    #[test]
-    fn test_path_shapes() {
-        for s in ["/abs/path", "./NAME", "../up", ".", "..", "some/dir"] {
-            assert!(
-                matches!(s.parse::<TicketRef>().unwrap(), TicketRef::Path(_)),
-                "expected path form for {s:?}"
-            );
-        }
-    }
-
-    /// A bare name is always an id — a ticket directory in cwd must be
-    /// written `./NAME`.
-    #[test]
-    fn test_bare_name_is_id() {
-        for s in ["JIRA-123", "my-ticket", "NAME"] {
-            assert!(
-                matches!(s.parse::<TicketRef>().unwrap(), TicketRef::Id(_)),
-                "expected id form for {s:?}"
-            );
-        }
-    }
-}
+pub use tix_sdk::discovery::TicketRef;
 
 /// Derives the branch name seeded into a new worktree:
 /// `<prefix>/<key>-<sanitized-description>` (v2 parity, spec §3.4).
@@ -178,11 +115,11 @@ mod branch_name_tests {
 /// Shared by every ticket subcommand; the "no [cli] section" error points at
 /// `tix config init` rather than leaking a parse detail.
 pub fn load_cli_config(
-    context: &crate::tix::context::Context,
-) -> Result<crate::tix::config::CliConfig, tix_engine::TixError> {
-    let document = crate::tix::document::TixDocument::load(&context.config_path)?;
+    context: &tix_sdk::context::Context,
+) -> Result<crate::tix::config::CliConfig, tix_sdk::SdkError> {
+    let document = tix_sdk::document::TixDocument::load(&context.config_path)?;
     document.section("cli")?.ok_or_else(|| {
-        tix_engine::TixError::Message(
+        tix_sdk::SdkError::Message(
             "global config has no [cli] section — run `tix config init`".to_string(),
         )
     })
@@ -192,18 +129,18 @@ pub fn load_cli_config(
 ///
 /// # Errors
 ///
-/// [`tix_engine::TixError::TicketNotFound`] when the document has no
+/// [`tix_sdk::TixError::TicketNotFound`] (wrapped) when the document has no
 /// `[ticket]` section; parse errors propagate from the document layer.
 pub fn load_ticket_config(
     ticket_root: &std::path::Path,
-) -> Result<tix_engine::TicketConfig, tix_engine::TixError> {
+) -> Result<tix_sdk::TicketConfig, tix_sdk::SdkError> {
     let document =
-        crate::tix::document::TixDocument::load(&ticket_root.join(".tix").join("ticket.toml"))?;
+        tix_sdk::document::TixDocument::load(&ticket_root.join(".tix").join("ticket.toml"))?;
     document.section("ticket")?.ok_or_else(|| {
-        tix_engine::TixError::TicketNotFound(format!(
+        tix_sdk::SdkError::Engine(tix_sdk::TixError::TicketNotFound(format!(
             "{} has no [ticket] section",
             ticket_root.join(".tix/ticket.toml").display()
-        ))
+        )))
     })
 }
 
@@ -214,14 +151,14 @@ pub fn load_ticket_config(
 /// command shares; commands that merely prefer context call the discovery
 /// layer directly.
 pub fn require_ticket_root(
-    context: &crate::tix::context::Context,
+    context: &tix_sdk::context::Context,
     ticket: Option<&TicketRef>,
-) -> Result<std::path::PathBuf, tix_engine::TixError> {
+) -> Result<std::path::PathBuf, tix_sdk::SdkError> {
     let cli = load_cli_config(context)?;
-    crate::tix::discovery::resolve_ticket_root(ticket, &cli.tickets_directory)?.ok_or_else(|| {
-        tix_engine::TixError::TicketNotFound(
+    tix_sdk::discovery::resolve_ticket_root(ticket, &cli.tickets_directory)?.ok_or_else(|| {
+        tix_sdk::SdkError::Engine(tix_sdk::TixError::TicketNotFound(
             "not inside a ticket — cd into one or pass --ticket <path|id>".to_string(),
-        )
+        ))
     })
 }
 

--- a/tix-cli/src/tix/ticket/remove.rs
+++ b/tix-cli/src/tix/ticket/remove.rs
@@ -1,10 +1,10 @@
 //! `tix ticket remove` — remove single worktrees from a ticket without
 //! destroying it.
 
-use crate::tix::context::Context;
-use crate::tix::document::{TixDocument, with_write};
+use tix_sdk::context::Context;
+use tix_sdk::document::{TixDocument, with_write};
 use crate::tix::ticket::{TicketSharedArgs, load_ticket_config, require_ticket_root};
-use tix_engine::{EngineConfig, TixError};
+use tix_sdk::{SdkError, EngineConfig, TixError};
 use tracing::info;
 
 /// Arguments for `tix ticket remove`.
@@ -30,7 +30,7 @@ pub struct Args {
 /// The ticket directory and every other worktree are untouched; removing
 /// the last worktree leaves a valid, empty ticket. Each successful prune is
 /// written back immediately through the format-preserving layer.
-pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
     let root = require_ticket_root(context, args.shared.ticket.as_ref())?;
     let ticket = load_ticket_config(&root)?;
 
@@ -51,10 +51,10 @@ pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
             ))
         })?;
         if !engine.configured_repositories.contains_key(&entry.repo) {
-            return Err(TixError::RepoNotFound(format!(
+            return Err(SdkError::Engine(TixError::RepoNotFound(format!(
                 "worktree '{}' belongs to '{}', which is no longer a registered repository",
                 name, entry.repo
-            )));
+            ))));
         }
     }
 

--- a/tix-cli/src/tix/ticket/setup.rs
+++ b/tix-cli/src/tix/ticket/setup.rs
@@ -1,13 +1,13 @@
 //! `tix ticket setup` — create a new ticket workspace with worktrees.
 
 use crate::tix::config::CliConfig;
-use crate::tix::context::Context;
-use crate::tix::document::TixDocument;
+use tix_sdk::context::Context;
+use tix_sdk::document::TixDocument;
 use crate::tix::repo::RepoAlias;
 use crate::tix::ticket::derive_branch_name;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use tix_engine::{Defaults, EngineConfig, TicketConfig, TixError, WorktreeConfig};
+use tix_sdk::{SdkError, Defaults, EngineConfig, TicketConfig, TixError, WorktreeConfig};
 use tracing::{error, info};
 
 /// Arguments for `tix ticket setup`.
@@ -42,9 +42,9 @@ pub struct Args {
 /// Partial failure leaves successfully created worktrees in place and
 /// records only them in `.tix/ticket.toml`; the command then errors naming
 /// the repos that failed.
-pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
+pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
     if args.key.is_empty() || args.key.contains(['/', '\\']) {
-        return Err(TixError::Message(format!(
+        return Err(SdkError::Message(format!(
             "'{}' is not a valid ticket key — keys are names, not paths (path-form creation is #114)",
             args.key
         )));
@@ -52,7 +52,7 @@ pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
 
     let document = TixDocument::load(&context.config_path)?;
     let cli: CliConfig = document.section("cli")?.ok_or_else(|| {
-        TixError::Message("global config has no [cli] section — run `tix config init`".to_string())
+        SdkError::Message("global config has no [cli] section — run `tix config init`".to_string())
     })?;
     let engine: EngineConfig = document.section_or_default("engine")?;
     let defaults: Defaults = document.section_or_default("defaults")?;
@@ -75,10 +75,10 @@ pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
                 .map(String::as_str)
                 .collect();
             known.sort();
-            return Err(TixError::RepoNotFound(format!(
+            return Err(SdkError::Engine(TixError::RepoNotFound(format!(
                 "'{alias}' is not a registered repository (registered: {})",
                 if known.is_empty() { "none".to_string() } else { known.join(", ") }
-            )));
+            ))));
         }
     }
 
@@ -92,13 +92,13 @@ pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
 
     let ticket_root: PathBuf = cli.tickets_directory.join(&args.key);
     if ticket_root.exists() {
-        return Err(TixError::Message(format!(
+        return Err(SdkError::Message(format!(
             "ticket '{}' already exists at {}",
             args.key,
             ticket_root.display()
         )));
     }
-    std::fs::create_dir_all(&ticket_root).map_err(TixError::IoError)?;
+    std::fs::create_dir_all(&ticket_root).map_err(SdkError::from)?;
 
     // --- create worktrees; collect successes and failures ---
     let mut worktrees: HashMap<String, WorktreeConfig> = HashMap::new();
@@ -140,7 +140,7 @@ pub fn run(context: &Context, args: Args) -> Result<(), TixError> {
 
     if !failures.is_empty() {
         let names: Vec<&str> = failures.iter().map(|(alias, _)| alias.as_str()).collect();
-        return Err(TixError::Message(format!(
+        return Err(SdkError::Message(format!(
             "ticket created, but {} of {} worktrees failed: {} — fix and `tix ticket add` them",
             failures.len(),
             selected.len(),

--- a/tix-cli/src/tix/utils.rs
+++ b/tix-cli/src/tix/utils.rs
@@ -22,26 +22,26 @@ pub enum OutputType {
 ///
 /// The prompt goes to stderr so interactive commands stay pipeable — stdout
 /// carries only results.
-pub fn prompt(label: &str, default: Option<&str>) -> Result<String, tix_engine::TixError> {
+pub fn prompt(label: &str, default: Option<&str>) -> Result<String, tix_sdk::SdkError> {
     use std::io::{BufRead, Write};
 
     match default {
         Some(default) => eprint!("{label} [{default}]: "),
         None => eprint!("{label}: "),
     }
-    std::io::stderr().flush().map_err(tix_engine::TixError::IoError)?;
+    std::io::stderr().flush().map_err(tix_sdk::SdkError::from)?;
 
     let mut answer = String::new();
     std::io::stdin()
         .lock()
         .read_line(&mut answer)
-        .map_err(tix_engine::TixError::IoError)?;
+        .map_err(tix_sdk::SdkError::from)?;
     let answer = answer.trim();
 
     match (answer.is_empty(), default) {
         (false, _) => Ok(answer.to_string()),
         (true, Some(default)) => Ok(default.to_string()),
-        (true, None) => Err(tix_engine::TixError::Message(format!(
+        (true, None) => Err(tix_sdk::SdkError::Message(format!(
             "{label} is required"
         ))),
     }

--- a/tix-engine/Cargo.toml
+++ b/tix-engine/Cargo.toml
@@ -4,11 +4,12 @@ version = "3.0.0"
 edition = "2024"
 
 [dependencies]
-dirs = "6.0.0"
 git2 = "0.21.0"
 serde = { version = "1.0.228", features = ["derive"] }
-toml = "1.1.2"
 tracing = "0.1.44"
 
 [dev-dependencies]
 tempfile = "3.27.0"
+# dev-only: round-trip tests and doctests of the serde section shapes.
+# Document parsing is the SDK's job (design/spec.md §2.2).
+toml = "1.1.2"

--- a/tix-engine/src/types/errors.rs
+++ b/tix-engine/src/types/errors.rs
@@ -6,12 +6,6 @@ pub enum TixError {
     GitError(git2::Error),
     /// An I/O operation failed.
     IoError(std::io::Error),
-    /// A TOML document could not be parsed.
-    ParseError(toml::de::Error),
-    /// A value could not be serialized to TOML.
-    SerializationError(toml::ser::Error),
-    /// The config file was not found at the given path.
-    ConfigNotFound(String),
     /// The repository was not found at the given path.
     RepoNotFound(String),
     /// The ticket directory was not found at the given path.
@@ -27,9 +21,6 @@ impl fmt::Display for TixError {
         match self {
             TixError::GitError(e) => write!(f, "git error: {}", e),
             TixError::IoError(e) => write!(f, "io error: {}", e),
-            TixError::ParseError(e) => write!(f, "serde error: {}", e),
-            TixError::SerializationError(e) => write!(f, "serialization error: {}", e),
-            TixError::ConfigNotFound(s) => write!(f, "config not found: {}", s),
             TixError::RepoNotFound(s) => write!(f, "repo not found: {}", s),
             TixError::TicketNotFound(s) => write!(f, "ticket not found: {}", s),
             TixError::WorktreeNotFound(s) => write!(f, "worktree not found: {}", s),
@@ -49,18 +40,6 @@ impl std::error::Error for TixError {}
 impl From<std::io::Error> for TixError {
     fn from(e: std::io::Error) -> Self {
         TixError::IoError(e)
-    }
-}
-
-impl From<toml::de::Error> for TixError {
-    fn from(e: toml::de::Error) -> Self {
-        TixError::ParseError(e)
-    }
-}
-
-impl From<toml::ser::Error> for TixError {
-    fn from(e: toml::ser::Error) -> Self {
-        TixError::SerializationError(e)
     }
 }
 
@@ -108,13 +87,6 @@ mod tests {
         ));
     }
 
-    /// `From<toml::de::Error>` wraps into `ParseError`.
-    #[test]
-    fn test_from_toml_de_error() {
-        let de_err = toml::from_str::<toml::Value>("[[[not valid").unwrap_err();
-        assert!(matches!(TixError::from(de_err), TixError::ParseError(_)));
-    }
-
     /// `Display` produces a non-empty string for every variant.
     #[test]
     fn test_display_non_empty() {
@@ -122,13 +94,9 @@ mod tests {
         let git_err = git2::Repository::open("/nonexistent/path/for/tix/test")
             .err()
             .unwrap();
-        let parse_err = toml::from_str::<toml::Value>("[[[").unwrap_err();
-
         let variants: Vec<TixError> = vec![
             TixError::GitError(git_err),
             TixError::IoError(io_err),
-            TixError::ParseError(parse_err),
-            TixError::ConfigNotFound("path".into()),
             TixError::RepoNotFound("path".into()),
             TixError::TicketNotFound("path".into()),
             TixError::WorktreeNotFound("path".into()),

--- a/tix-engine/src/types/repository.rs
+++ b/tix-engine/src/types/repository.rs
@@ -141,18 +141,6 @@ pub struct Repository {
 }
 
 impl Repository {
-    /// Creates a new `Repository` from an alias, config, and an already-open [`git2::Repository`].
-    ///
-    /// Prefer constructing via [`RepositoryConfig::resolve`] or [`RepositoryConfig::clone_remote`]
-    /// rather than calling this directly.
-    pub(crate) fn new(alias: String, config: RepositoryConfig, repo: git2::Repository) -> Self {
-        Self {
-            alias,
-            config,
-            repo,
-        }
-    }
-
     /// Creates a git worktree named `name` for `branch` at `path`.
     ///
     /// `name` is the worktree directory name under the ticket root — the key

--- a/tix-sdk/Cargo.toml
+++ b/tix-sdk/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tix-sdk"
+version = "3.0.0"
+edition = "2024"
+
+[dependencies]
+dirs = "6.0.0"
+serde = { version = "1.0.228", features = ["derive"] }
+tix-engine = { path = "../tix-engine" }
+toml = "1.1.2"
+toml_edit = { version = "0.25.13", features = ["serde"] }
+tracing = "0.1.44"
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/tix-sdk/PROTOCOL.md
+++ b/tix-sdk/PROTOCOL.md
@@ -1,0 +1,23 @@
+# tix host ↔ plugin protocol
+
+The `--tix-protocol` integer is the **only** compatibility boundary between
+a `tix` host and a separately-compiled plugin. Crate versions carry no
+compatibility semantics (`design/spec.md` §2.3).
+
+Rules (spec §5.4):
+
+- Monotonic, starting at 1. The SDK's compiled-in value is
+  `tix_sdk::host::PROTOCOL`.
+- Bump **only** for removal, rename, or semantic change of an existing flag
+  or document. **Never for additions** — the SDK ignores unknown `--tix-*`
+  flags, so additions are safe by construction, and flag presence doubles as
+  capability detection.
+- On mismatch the SDK fails with "built for protocol N, host speaks M —
+  rebuild" and exits **125** (`host::PROTOCOL_MISMATCH_EXIT`), which the
+  host excludes from the propagated exit-code range.
+
+## Version → change table
+
+| Protocol | Introduced | Changes |
+|----------|------------|---------|
+| 1 | v3.0 | Initial contract: `--tix-protocol`, `--tix-config`, `--tix-ticket` (only inside a ticket), `--tix-delta`, `--tix-repo` / `--tix-repo-dir` (only inside a repo worktree), `--tix-log-level`, `--tix-output`, `--tix-color`; JSON delta diff-back applied on exit 0; `TIX_DEPTH` fork-bomb cap; exit 125 reserved. |

--- a/tix-sdk/examples/toy-plugin.rs
+++ b/tix-sdk/examples/toy-plugin.rs
@@ -1,0 +1,40 @@
+//! The smallest possible tix plugin — `tix-toy`.
+//!
+//! Demonstrates (and continuously compiles) the plugin side of the
+//! invocation contract: parse host flags, answer `print-cli-help`, pass the
+//! protocol check, read your own `[toy]` section, and see your user args.
+//!
+//! Try it by hand (plugins take real paths, so no host is needed):
+//!
+//! ```text
+//! cargo run -p tix-sdk --example toy-plugin -- \
+//!     --tix-protocol 1 --tix-config ~/.config/tix/config.toml hello --loud
+//! ```
+
+use serde::Deserialize;
+use tix_sdk::document::TixDocument;
+use tix_sdk::host::HostContext;
+
+/// The plugin's own `[toy]` table in global config — its schema belongs to
+/// the plugin alone; tix never deserializes it.
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct ToyConfig {
+    greeting: Option<String>,
+}
+
+fn main() {
+    // Handles print-cli-help, strips --tix-*, checks the protocol (exit 125
+    // on mismatch), and errors usefully when run without --tix-config.
+    let host = HostContext::from_env_or_exit("a toy plugin demonstrating the tix SDK");
+
+    let document = TixDocument::load(&host.config_path).expect("config parses");
+    let config: ToyConfig = document
+        .section_or_default("toy")
+        .expect("[toy] section parses");
+
+    let greeting = config.greeting.unwrap_or_else(|| "hello".to_string());
+    println!("{greeting} from tix-toy!");
+    println!("  ticket:    {:?}", host.ticket_root);
+    println!("  user args: {:?}", host.user_args);
+}

--- a/tix-sdk/src/context.rs
+++ b/tix-sdk/src/context.rs
@@ -3,15 +3,15 @@
 //!
 //! Config path resolution is stage 1 of the read path (`design/spec.md`
 //! §3.3) and belongs to the frontend/SDK — the engine never reads env vars
-//! or flags. Written in `tix-cli` first; promoted to `tix-sdk` (#96) so
-//! plugins resolve identically.
+//! or flags. Written in `tix-cli` first (#52); promoted here (#96) so plugins
+//! resolve identically.
 //!
 //! The default location is deliberately isolated in [`default_config_path`]
 //! so it can be revisited without touching resolution or call sites.
 
 use std::ffi::OsString;
 use std::path::PathBuf;
-use tix_engine::TixError;
+use crate::error::SdkError;
 use tracing::debug;
 
 /// The environment variable overriding the global config location, beaten
@@ -31,9 +31,9 @@ impl Context {
     ///
     /// # Errors
     ///
-    /// [`TixError::ConfigNotFound`] if no flag or env var is set and the
+    /// [`SdkError::ConfigNotFound`] if no flag or env var is set and the
     /// platform config directory cannot be determined.
-    pub fn resolve(config_flag: Option<PathBuf>) -> Result<Self, TixError> {
+    pub fn resolve(config_flag: Option<PathBuf>) -> Result<Self, SdkError> {
         Ok(Self {
             config_path: resolve_config_path(config_flag)?,
         })
@@ -46,11 +46,11 @@ impl Context {
     ///
     /// # Errors
     ///
-    /// [`TixError::ConfigNotFound`] with the resolved path and a pointer at
+    /// [`SdkError::ConfigNotFound`] with the resolved path and a pointer at
     /// `tix config init` when the file does not exist.
-    pub fn require_config_path(&self) -> Result<&PathBuf, TixError> {
+    pub fn require_config_path(&self) -> Result<&PathBuf, SdkError> {
         if !self.config_path.is_file() {
-            return Err(TixError::ConfigNotFound(format!(
+            return Err(SdkError::ConfigNotFound(format!(
                 "no config file at {} — run `tix config init` to create one",
                 self.config_path.display()
             )));
@@ -68,9 +68,9 @@ impl Context {
 ///
 /// # Errors
 ///
-/// [`TixError::ConfigNotFound`] if neither flag nor env var is set and the
+/// [`SdkError::ConfigNotFound`] if neither flag nor env var is set and the
 /// platform config directory cannot be determined.
-pub fn resolve_config_path(flag: Option<PathBuf>) -> Result<PathBuf, TixError> {
+pub fn resolve_config_path(flag: Option<PathBuf>) -> Result<PathBuf, SdkError> {
     resolve_from(
         flag,
         std::env::var_os(CONFIG_PATH_ENV),
@@ -95,7 +95,7 @@ fn resolve_from(
     flag: Option<PathBuf>,
     env: Option<OsString>,
     default: Option<PathBuf>,
-) -> Result<PathBuf, TixError> {
+) -> Result<PathBuf, SdkError> {
     if let Some(path) = flag {
         debug!(path = %path.display(), "config path from --config flag");
         return Ok(path);
@@ -108,7 +108,7 @@ fn resolve_from(
         return Ok(path);
     }
     default.ok_or_else(|| {
-        TixError::ConfigNotFound(
+        SdkError::ConfigNotFound(
             "cannot determine the platform config directory; \
              pass --config or set TIX_CONFIG_PATH"
                 .to_string(),
@@ -173,7 +173,7 @@ mod tests {
     fn test_no_source_errors() {
         assert!(matches!(
             resolve_from(None, None, None),
-            Err(TixError::ConfigNotFound(_))
+            Err(SdkError::ConfigNotFound(_))
         ));
     }
 
@@ -197,7 +197,7 @@ mod tests {
 
         assert!(matches!(
             ctx.require_config_path(),
-            Err(TixError::ConfigNotFound(_))
+            Err(SdkError::ConfigNotFound(_))
         ));
 
         std::fs::write(&path, "").unwrap();

--- a/tix-sdk/src/discovery.rs
+++ b/tix-sdk/src/discovery.rs
@@ -14,10 +14,44 @@
 //!   starting points — a near-miss (e.g. a subdirectory of a ticket) errors
 //!   rather than re-walking.
 
-use crate::tix::ticket::TicketRef;
 use std::path::{Path, PathBuf};
+use crate::error::SdkError;
 use tix_engine::TixError;
 use tracing::debug;
+
+
+/// A `--ticket` argument: one flag, two forms, disambiguated by shape
+/// (`design/spec.md` §4).
+///
+/// - **Path** — the argument contains a path separator, is absolute, or is
+///   `.`/`..`. Asserts *this path is the ticket root*.
+/// - **Id** — any bare name, resolved against the configured tickets
+///   directory.
+///
+/// A bare name is always an id; a ticket directory in cwd must be written
+/// `./NAME`. See [`resolve_override`] for the resolution semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TicketRef {
+    /// An asserted ticket-root path (`./NAME`, `some/dir`, `/abs/path`, `.`, `..`).
+    Path(PathBuf),
+    /// A bare ticket id, resolved as `tickets_directory.join(id)`.
+    Id(String),
+}
+
+impl std::str::FromStr for TicketRef {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let path = Path::new(s);
+        let is_path_shape =
+            s == "." || s == ".." || path.is_absolute() || s.contains(['/', '\\']);
+        if is_path_shape {
+            Ok(TicketRef::Path(path.to_path_buf()))
+        } else {
+            Ok(TicketRef::Id(s.to_string()))
+        }
+    }
+}
 
 /// Returns true if `path` is a ticket root: a directory containing the file
 /// `.tix/ticket.toml`.
@@ -38,8 +72,8 @@ pub fn is_ticket_root(path: &Path) -> bool {
 /// sees in their prompt, matching git's behavior. `$PWD` is trusted only when
 /// it is absolute and still names the same directory as the process cwd;
 /// otherwise the process cwd is the fallback.
-pub fn logical_cwd() -> Result<PathBuf, TixError> {
-    let process_cwd = std::env::current_dir().map_err(TixError::IoError)?;
+pub fn logical_cwd() -> Result<PathBuf, SdkError> {
+    let process_cwd = std::env::current_dir().map_err(|e| SdkError::Engine(TixError::IoError(e)))?;
     if let Some(pwd) = std::env::var_os("PWD") {
         let pwd = PathBuf::from(pwd);
         if pwd.is_absolute() && same_directory(&pwd, &process_cwd) {
@@ -55,7 +89,7 @@ pub fn logical_cwd() -> Result<PathBuf, TixError> {
 /// Returns `Ok(None)` when no ancestor is a ticket root — commands that
 /// require ticket context should turn that into a clear error; there is
 /// deliberately **no** fallback to the tickets directory.
-pub fn discover_ticket_root() -> Result<Option<PathBuf>, TixError> {
+pub fn discover_ticket_root() -> Result<Option<PathBuf>, SdkError> {
     Ok(discover_ticket_root_from(&logical_cwd()?))
 }
 
@@ -107,17 +141,17 @@ pub fn discover_ticket_root_from(start: &Path) -> Option<PathBuf> {
 /// # Errors
 ///
 /// [`TixError::TicketNotFound`] if the asserted path is not a ticket root.
-pub fn resolve_override(ticket: &TicketRef, tickets_directory: &Path) -> Result<PathBuf, TixError> {
+pub fn resolve_override(ticket: &TicketRef, tickets_directory: &Path) -> Result<PathBuf, SdkError> {
     let (root, described) = match ticket {
         TicketRef::Path(path) => (path.clone(), format!("path '{}'", path.display())),
         TicketRef::Id(id) => (tickets_directory.join(id), format!("ticket id '{id}'")),
     };
 
     if !is_ticket_root(&root) {
-        return Err(TixError::TicketNotFound(format!(
+        return Err(SdkError::Engine(TixError::TicketNotFound(format!(
             "{described} is not a ticket root (no .tix/ticket.toml at {})",
             root.display()
-        )));
+        ))));
     }
 
     if !root.starts_with(tickets_directory) {
@@ -140,7 +174,7 @@ pub fn resolve_override(ticket: &TicketRef, tickets_directory: &Path) -> Result<
 pub fn resolve_ticket_root(
     ticket: Option<&TicketRef>,
     tickets_directory: &Path,
-) -> Result<Option<PathBuf>, TixError> {
+) -> Result<Option<PathBuf>, SdkError> {
     match ticket {
         Some(ticket_ref) => resolve_override(ticket_ref, tickets_directory).map(Some),
         None => discover_ticket_root(),
@@ -294,7 +328,7 @@ mod tests {
 
         assert!(matches!(
             resolve_override(&TicketRef::Path(subdir), dir.path()),
-            Err(TixError::TicketNotFound(_))
+            Err(SdkError::Engine(TixError::TicketNotFound(_)))
         ));
     }
 
@@ -316,7 +350,7 @@ mod tests {
         let dir = tempdir().unwrap();
         assert!(matches!(
             resolve_override(&TicketRef::Id("NOPE-404".to_string()), dir.path()),
-            Err(TixError::TicketNotFound(_))
+            Err(SdkError::Engine(TixError::TicketNotFound(_)))
         ));
     }
 

--- a/tix-sdk/src/document.rs
+++ b/tix-sdk/src/document.rs
@@ -15,14 +15,14 @@
 //! silently dropping every `[<plugin>]` table plus all comments (spec §6.2).
 //! Every write in tix goes through this layer instead.
 //!
-//! Written in `tix-cli` first; promoted to `tix-sdk` (#96) so plugins parse
+//! Written in `tix-cli` first; promoted here (#96) so plugins parse
 //! documents identically.
 
 use serde::de::DeserializeOwned;
 use std::fmt;
 use std::fs::File;
 use std::path::{Path, PathBuf};
-use tix_engine::TixError;
+use crate::error::SdkError;
 use tracing::debug;
 
 /// A parsed tix config document: a format-preserving TOML DOM with typed
@@ -54,11 +54,11 @@ impl TixDocument {
     ///
     /// # Errors
     ///
-    /// [`TixError::Message`] with the parse diagnostic on invalid TOML.
-    pub fn parse(text: &str) -> Result<Self, TixError> {
+    /// [`SdkError::Message`] with the parse diagnostic on invalid TOML.
+    pub fn parse(text: &str) -> Result<Self, SdkError> {
         let doc = text
             .parse::<toml_edit::DocumentMut>()
-            .map_err(|e| TixError::Message(format!("invalid TOML: {e}")))?;
+            .map_err(|e| SdkError::Message(format!("invalid TOML: {e}")))?;
         Ok(Self { doc })
     }
 
@@ -68,11 +68,11 @@ impl TixDocument {
     ///
     /// # Errors
     ///
-    /// - [`TixError::IoError`] if the file cannot be read
-    /// - [`TixError::Message`] on invalid TOML
-    pub fn load(path: &Path) -> Result<Self, TixError> {
+    /// - [`SdkError::from`] if the file cannot be read
+    /// - [`SdkError::Message`] on invalid TOML
+    pub fn load(path: &Path) -> Result<Self, SdkError> {
         let _lock = SidecarLock::shared(path)?;
-        let text = std::fs::read_to_string(path).map_err(TixError::IoError)?;
+        let text = std::fs::read_to_string(path).map_err(SdkError::from)?;
         Self::parse(&text)
     }
 
@@ -85,10 +85,10 @@ impl TixDocument {
     ///
     /// # Errors
     ///
-    /// [`TixError::Message`] when the section exists but does not deserialize
+    /// [`SdkError::Message`] when the section exists but does not deserialize
     /// into `T` (including `deny_unknown_fields` violations, which apply to
     /// this section's subtree only).
-    pub fn section<T: DeserializeOwned>(&self, name: &str) -> Result<Option<T>, TixError> {
+    pub fn section<T: DeserializeOwned>(&self, name: &str) -> Result<Option<T>, SdkError> {
         let Some(item) = self.doc.get(name) else {
             return Ok(None);
         };
@@ -97,7 +97,7 @@ impl TixDocument {
         let mut section_doc = toml_edit::DocumentMut::new();
         *section_doc.as_item_mut() = item.clone();
         let value = toml_edit::de::from_document(section_doc)
-            .map_err(|e| TixError::Message(format!("invalid [{name}] section: {e}")))?;
+            .map_err(|e| SdkError::Message(format!("invalid [{name}] section: {e}")))?;
         Ok(Some(value))
     }
 
@@ -110,7 +110,7 @@ impl TixDocument {
     pub fn section_or_default<T: DeserializeOwned + Default>(
         &self,
         name: &str,
-    ) -> Result<T, TixError> {
+    ) -> Result<T, SdkError> {
         Ok(self.section(name)?.unwrap_or_default())
     }
 
@@ -135,17 +135,17 @@ impl TixDocument {
     ///
     /// # Errors
     ///
-    /// [`TixError::SerializationError`] if `value` does not serialize to a
+    /// [`SdkError::Serialization`] if `value` does not serialize to a
     /// TOML table.
     pub fn set_section<T: serde::Serialize>(
         &mut self,
         name: &str,
         value: &T,
-    ) -> Result<(), TixError> {
+    ) -> Result<(), SdkError> {
         let text = toml::to_string(value)?;
         let section: toml_edit::DocumentMut = text
             .parse()
-            .map_err(|e| TixError::Message(format!("serialized [{name}] is not a table: {e}")))?;
+            .map_err(|e| SdkError::Message(format!("serialized [{name}] is not a table: {e}")))?;
         self.doc.insert(name, section.as_item().clone());
         Ok(())
     }
@@ -160,11 +160,11 @@ impl TixDocument {
     ///
     /// # Errors
     ///
-    /// [`TixError::IoError`] if the temp write or rename fails.
-    pub fn save(&self, path: &Path) -> Result<(), TixError> {
+    /// [`SdkError::from`] if the temp write or rename fails.
+    pub fn save(&self, path: &Path) -> Result<(), SdkError> {
         // Parent dirs must exist before the sidecar lock can be opened there.
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(TixError::IoError)?;
+            std::fs::create_dir_all(parent).map_err(SdkError::from)?;
         }
         let _lock = SidecarLock::exclusive(path)?;
         self.save_unlocked(path)
@@ -174,13 +174,13 @@ impl TixDocument {
     /// its own exclusive lock across the full load → mutate → rename cycle.
     /// Parent directories must already exist (the lock lives in the same
     /// directory, so callers create them before locking).
-    fn save_unlocked(&self, path: &Path) -> Result<(), TixError> {
+    fn save_unlocked(&self, path: &Path) -> Result<(), SdkError> {
         let tmp = sibling_tmp_path(path);
-        std::fs::write(&tmp, self.doc.to_string()).map_err(TixError::IoError)?;
+        std::fs::write(&tmp, self.doc.to_string()).map_err(SdkError::from)?;
         std::fs::rename(&tmp, path).map_err(|e| {
             // Leave no droppings on a failed rename.
             let _ = std::fs::remove_file(&tmp);
-            TixError::IoError(e)
+            SdkError::from(e)
         })?;
         debug!(path = %path.display(), "document saved atomically");
         Ok(())
@@ -216,15 +216,15 @@ impl fmt::Display for TixDocument {
 /// ```
 pub fn with_write<T>(
     path: &Path,
-    mutate: impl FnOnce(&mut TixDocument) -> Result<T, TixError>,
-) -> Result<T, TixError> {
+    mutate: impl FnOnce(&mut TixDocument) -> Result<T, SdkError>,
+) -> Result<T, SdkError> {
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(TixError::IoError)?;
+        std::fs::create_dir_all(parent).map_err(SdkError::from)?;
     }
     let _lock = SidecarLock::exclusive(path)?;
     let mut document = if path.exists() {
         // Fresh parse under the lock, never a caller-held snapshot.
-        let text = std::fs::read_to_string(path).map_err(TixError::IoError)?;
+        let text = std::fs::read_to_string(path).map_err(SdkError::from)?;
         TixDocument::parse(&text)?
     } else {
         TixDocument::empty()
@@ -245,25 +245,25 @@ struct SidecarLock {
 }
 
 impl SidecarLock {
-    fn shared(document_path: &Path) -> Result<Self, TixError> {
+    fn shared(document_path: &Path) -> Result<Self, SdkError> {
         let file = Self::open(document_path)?;
-        file.lock_shared().map_err(TixError::IoError)?;
+        file.lock_shared().map_err(SdkError::from)?;
         Ok(Self { file })
     }
 
-    fn exclusive(document_path: &Path) -> Result<Self, TixError> {
+    fn exclusive(document_path: &Path) -> Result<Self, SdkError> {
         let file = Self::open(document_path)?;
-        file.lock().map_err(TixError::IoError)?;
+        file.lock().map_err(SdkError::from)?;
         Ok(Self { file })
     }
 
-    fn open(document_path: &Path) -> Result<File, TixError> {
+    fn open(document_path: &Path) -> Result<File, SdkError> {
         File::options()
             .create(true)
             .truncate(false)
             .write(true)
             .open(lock_path(document_path))
-            .map_err(TixError::IoError)
+            .map_err(SdkError::from)
     }
 }
 
@@ -435,8 +435,8 @@ retries = 3
         let path = dir.path().join("config.toml");
         std::fs::write(&path, DOCUMENT).unwrap();
 
-        let result: Result<(), TixError> =
-            with_write(&path, |_doc| Err(TixError::Message("nope".to_string())));
+        let result: Result<(), SdkError> =
+            with_write(&path, |_doc| Err(SdkError::Message("nope".to_string())));
         assert!(result.is_err());
         assert_eq!(std::fs::read_to_string(&path).unwrap(), DOCUMENT);
     }

--- a/tix-sdk/src/error.rs
+++ b/tix-sdk/src/error.rs
@@ -1,0 +1,83 @@
+//! The SDK's error type.
+//!
+//! Document parsing and serialization are SDK concerns (`design/spec.md`
+//! §2.2) — the `ParseError`/`SerializationError` variants that used to live
+//! on the engine's [`TixError`] migrate here, so `tix-engine` carries no
+//! runtime `toml` dependency.
+
+use std::fmt;
+use tix_engine::TixError;
+
+/// An error from the SDK's context-and-consistency layer, or from the
+/// engine underneath it.
+pub enum SdkError {
+    /// An engine operation failed.
+    Engine(TixError),
+    /// A TOML document could not be parsed.
+    Parse(toml::de::Error),
+    /// A value could not be serialized to TOML.
+    Serialization(toml::ser::Error),
+    /// The config file was not found at the resolved path.
+    ///
+    /// Migrated from the engine: config location is an SDK concern, and the
+    /// engine never touches config paths.
+    ConfigNotFound(String),
+    /// A freeform SDK-level error message.
+    Message(String),
+}
+
+impl fmt::Display for SdkError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SdkError::Engine(e) => fmt::Display::fmt(e, f),
+            SdkError::Parse(e) => write!(f, "parse error: {}", e),
+            SdkError::Serialization(e) => write!(f, "serialization error: {}", e),
+            SdkError::ConfigNotFound(s) => write!(f, "config not found: {}", s),
+            SdkError::Message(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl fmt::Debug for SdkError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl std::error::Error for SdkError {}
+
+impl From<TixError> for SdkError {
+    fn from(e: TixError) -> Self {
+        SdkError::Engine(e)
+    }
+}
+
+impl From<toml::de::Error> for SdkError {
+    fn from(e: toml::de::Error) -> Self {
+        SdkError::Parse(e)
+    }
+}
+
+impl From<toml::ser::Error> for SdkError {
+    fn from(e: toml::ser::Error) -> Self {
+        SdkError::Serialization(e)
+    }
+}
+
+impl From<std::io::Error> for SdkError {
+    fn from(e: std::io::Error) -> Self {
+        SdkError::Engine(TixError::IoError(e))
+    }
+}
+
+impl From<String> for SdkError {
+    fn from(s: String) -> Self {
+        SdkError::Message(s)
+    }
+}
+
+impl From<&str> for SdkError {
+    fn from(s: &str) -> Self {
+        SdkError::Message(s.to_string())
+    }
+}

--- a/tix-sdk/src/host.rs
+++ b/tix-sdk/src/host.rs
@@ -1,0 +1,302 @@
+//! The plugin side of the invocation contract (`design/spec.md` §5).
+//!
+//! A plugin binary's first act is [`HostContext::from_env`]: it answers the
+//! bare `print-cli-help` handshake, strips every `--tix-*` flag out of argv,
+//! checks the protocol, and hands back settled host values plus untouched
+//! user args. The host resolved its globals before forwarding — plugins MUST
+//! NOT reimplement flag precedence.
+
+use crate::error::SdkError;
+use std::path::PathBuf;
+
+/// The protocol integer this SDK speaks.
+///
+/// Monotonic, starting at 1, independent of crate versions. Bumped **only**
+/// for removal, rename, or semantic change of an existing flag or document —
+/// never for additions (unknown `--tix-*` flags are ignored, so additions
+/// are safe by construction and flag presence doubles as capability
+/// detection). The version → change table lives in `tix-sdk/PROTOCOL.md`.
+pub const PROTOCOL: u64 = 1;
+
+/// Exit code reserved for protocol mismatch (`design/spec.md` §6.4).
+///
+/// The established tool-layer-error slot (`docker run`, `timeout(1)`,
+/// `git bisect run` skip); excluded from the host's propagated range.
+pub const PROTOCOL_MISMATCH_EXIT: i32 = 125;
+
+/// Settled host values handed to a plugin, plus the user's own args.
+///
+/// Paths are the real files, not staged copies — a plugin can be hand-run
+/// against arbitrary paths for debugging.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HostContext {
+    /// Path to the global config file.
+    pub config_path: PathBuf,
+    /// Path to the ticket directory (parent of `.tix`) — present only when
+    /// the host ran inside a ticket. The absence is load-bearing:
+    /// `tix ticket setup` creates tickets, so it runs without one.
+    pub ticket_root: Option<PathBuf>,
+    /// Host-created temp file for the outbound config delta. Stdout cannot
+    /// carry it — stdout belongs to the user. No file written ⇒ no changes.
+    pub delta_path: Option<PathBuf>,
+    /// Alias of the repo worktree cwd is inside, when it is.
+    pub repo: Option<String>,
+    /// Path of that worktree.
+    pub repo_dir: Option<PathBuf>,
+    /// The host's resolved log level.
+    pub log_level: Option<String>,
+    /// The host's resolved output format (`json`/`toml`/`default`).
+    pub output: Option<String>,
+    /// The host's resolved color decision for this process.
+    pub color: Option<bool>,
+    /// Everything that was not a `--tix-*` flag, in order — the user's args,
+    /// untouched.
+    pub user_args: Vec<String>,
+}
+
+impl HostContext {
+    /// Parses the process's own argv. See [`Self::from_args`].
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::from_args`].
+    pub fn from_env() -> Result<Self, SdkError> {
+        Self::from_args(std::env::args().skip(1))
+    }
+
+    /// Parses host-injected flags out of `args`.
+    ///
+    /// - `print-cli-help` as the sole argument is handled **before** any
+    ///   host flag is required (it is invoked bare, spec §5.6): the plugin's
+    ///   registered description prints and the process exits 0. Register one
+    ///   with [`Self::from_args_with_description`].
+    /// - Known `--tix-*` flags are collected; **unknown `--tix-*` flags are
+    ///   ignored** — additions never break older plugins, and checking
+    ///   [`HostContext`] fields doubles as capability detection.
+    /// - `--tix-protocol` is compared against [`PROTOCOL`]; a mismatch is a
+    ///   *rebuild* situation, reported as such — callers should exit with
+    ///   [`PROTOCOL_MISMATCH_EXIT`] (or use [`Self::from_env_or_exit`]).
+    ///
+    /// # Errors
+    ///
+    /// - [`SdkError::Message`] on protocol mismatch ("built for protocol N,
+    ///   host speaks M — rebuild")
+    /// - [`SdkError::Message`] when `--tix-config` is missing — the one flag
+    ///   every host invocation carries
+    pub fn from_args(args: impl IntoIterator<Item = String>) -> Result<Self, SdkError> {
+        Self::parse(args, None)
+    }
+
+    /// [`Self::from_args`], answering `print-cli-help` with `description`.
+    pub fn from_args_with_description(
+        args: impl IntoIterator<Item = String>,
+        description: &str,
+    ) -> Result<Self, SdkError> {
+        Self::parse(args, Some(description))
+    }
+
+    /// [`Self::from_env`], turning errors into the contract's process exits:
+    /// protocol mismatch exits [`PROTOCOL_MISMATCH_EXIT`], anything else
+    /// prints to stderr and exits 1. The convenience entry point for plugin
+    /// `main`s.
+    pub fn from_env_or_exit(description: &str) -> Self {
+        match Self::parse(std::env::args().skip(1), Some(description)) {
+            Ok(context) => context,
+            Err(SdkError::Message(message)) if message.contains("— rebuild") => {
+                eprintln!("error: {message}");
+                std::process::exit(PROTOCOL_MISMATCH_EXIT);
+            }
+            Err(e) => {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    fn parse(
+        args: impl IntoIterator<Item = String>,
+        description: Option<&str>,
+    ) -> Result<Self, SdkError> {
+        let args: Vec<String> = args.into_iter().collect();
+
+        // The handshake is answered before any host flag is required.
+        if description.is_some() && args.iter().map(String::as_str).eq(["print-cli-help"]) {
+            println!("{}", description.unwrap_or_default());
+            std::process::exit(0);
+        }
+
+        let mut protocol: Option<u64> = None;
+        let mut config_path: Option<PathBuf> = None;
+        let mut ticket_root: Option<PathBuf> = None;
+        let mut delta_path: Option<PathBuf> = None;
+        let mut repo: Option<String> = None;
+        let mut repo_dir: Option<PathBuf> = None;
+        let mut log_level: Option<String> = None;
+        let mut output: Option<String> = None;
+        let mut color: Option<bool> = None;
+        let mut user_args: Vec<String> = Vec::new();
+
+        let mut iter = args.into_iter().peekable();
+        while let Some(arg) = iter.next() {
+            // The whole --tix-* prefix is reserved for the host; everything
+            // else passes through untouched.
+            let Some(flag) = arg.strip_prefix("--tix-") else {
+                user_args.push(arg);
+                continue;
+            };
+            // Both `--tix-flag value` and `--tix-flag=value` forms parse.
+            let (name, value) = match flag.split_once('=') {
+                Some((name, value)) => (name.to_string(), Some(value.to_string())),
+                None => (flag.to_string(), iter.next()),
+            };
+            let value = value.unwrap_or_default();
+            match name.as_str() {
+                "protocol" => protocol = value.parse().ok(),
+                "config" => config_path = Some(PathBuf::from(value)),
+                "ticket" => ticket_root = Some(PathBuf::from(value)),
+                "delta" => delta_path = Some(PathBuf::from(value)),
+                "repo" => repo = Some(value),
+                "repo-dir" => repo_dir = Some(PathBuf::from(value)),
+                "log-level" => log_level = Some(value),
+                "output" => output = Some(value),
+                "color" => color = value.parse().ok(),
+                // Unknown --tix-* flags are ignored by contract: additions
+                // are safe with no protocol bump.
+                _ => {}
+            }
+        }
+
+        if let Some(sent) = protocol
+            && sent != PROTOCOL
+        {
+            return Err(SdkError::Message(format!(
+                "built for protocol {PROTOCOL}, host speaks {sent} — rebuild"
+            )));
+        }
+
+        let config_path = config_path.ok_or_else(|| {
+            SdkError::Message(
+                "no --tix-config flag: this binary is a tix plugin, run it through `tix <name>` \
+                 (or pass --tix-config <path> by hand for debugging)"
+                    .to_string(),
+            )
+        })?;
+
+        Ok(Self {
+            config_path,
+            ticket_root,
+            delta_path,
+            repo,
+            repo_dir,
+            log_level,
+            output,
+            color,
+            user_args,
+        })
+    }
+
+    /// The ticket root, for plugins that require ticket context.
+    ///
+    /// # Errors
+    ///
+    /// [`SdkError::Message`] with a user-facing "run inside a ticket" error
+    /// when the host forwarded none.
+    pub fn require_ticket(&self) -> Result<&PathBuf, SdkError> {
+        self.ticket_root.as_ref().ok_or_else(|| {
+            SdkError::Message(
+                "this command requires ticket context — run it from inside a ticket \
+                 or pass --ticket <path|id>"
+                    .to_string(),
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(list: &[&str]) -> impl Iterator<Item = String> + use<> {
+        list.iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
+    /// Host flags are stripped, user args survive untouched and in order.
+    #[test]
+    fn test_strips_host_flags_keeps_user_args() {
+        let context = HostContext::from_args(args(&[
+            "--tix-protocol",
+            "1",
+            "--tix-config",
+            "/cfg.toml",
+            "--tix-delta=/tmp/delta.json",
+            "sync",
+            "--verbose",
+            "some-file",
+        ]))
+        .unwrap();
+        assert_eq!(context.config_path, PathBuf::from("/cfg.toml"));
+        assert_eq!(context.delta_path, Some(PathBuf::from("/tmp/delta.json")));
+        assert_eq!(context.user_args, vec!["sync", "--verbose", "some-file"]);
+    }
+
+    /// Unknown --tix-* flags are ignored — additions need no protocol bump.
+    #[test]
+    fn test_ignores_unknown_tix_flags() {
+        let context = HostContext::from_args(args(&[
+            "--tix-config",
+            "/cfg.toml",
+            "--tix-shiny-new-flag",
+            "whatever",
+            "user-arg",
+        ]))
+        .unwrap();
+        assert_eq!(context.user_args, vec!["user-arg"]);
+    }
+
+    /// A protocol mismatch reports "rebuild", not a parse failure.
+    #[test]
+    fn test_protocol_mismatch() {
+        let err = HostContext::from_args(args(&[
+            "--tix-protocol",
+            "999",
+            "--tix-config",
+            "/cfg.toml",
+        ]))
+        .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("built for protocol 1"), "{message}");
+        assert!(message.contains("host speaks 999"), "{message}");
+        assert!(message.contains("rebuild"), "{message}");
+    }
+
+    /// Ticket context is optional and its absence is load-bearing.
+    #[test]
+    fn test_ticket_optional() {
+        let context =
+            HostContext::from_args(args(&["--tix-config", "/cfg.toml"])).unwrap();
+        assert!(context.ticket_root.is_none());
+        assert!(context.require_ticket().is_err());
+
+        let context = HostContext::from_args(args(&[
+            "--tix-config",
+            "/cfg.toml",
+            "--tix-ticket",
+            "/tickets/JIRA-1",
+        ]))
+        .unwrap();
+        assert_eq!(
+            context.require_ticket().unwrap(),
+            &PathBuf::from("/tickets/JIRA-1")
+        );
+    }
+
+    /// Missing --tix-config points at running through the host.
+    #[test]
+    fn test_missing_config_flag() {
+        let err = HostContext::from_args(args(&["user-arg"])).unwrap_err();
+        assert!(err.to_string().contains("tix plugin"));
+    }
+}

--- a/tix-sdk/src/lib.rs
+++ b/tix-sdk/src/lib.rs
@@ -1,0 +1,43 @@
+#![deny(missing_docs)]
+//! The context-and-consistency layer shared by `tix-cli` and plugins.
+//!
+//! `tix-sdk` is deliberately coupled to `tix-cli`: it is the CLI's own
+//! context layer, shipped as a crate so plugins inherit identical behavior
+//! for free. Surface grows by **promotion from `tix-cli`** — a helper the
+//! CLI wants applied consistently moves here — never by speculation about
+//! plugin needs (`design/2026-07-18.md`).
+//!
+//! What lives here:
+//!
+//! - [`context`] — global config path resolution
+//!   (`--config` > `TIX_CONFIG_PATH` > platform default).
+//! - [`discovery`] — the ticket walk and `--ticket` override semantics.
+//! - [`document`] — the format-preserving TOML document layer: generic
+//!   parse, typed section extraction, atomic locked writes.
+//! - [`host`] — the plugin side of the invocation contract: `--tix-*` flag
+//!   parsing and the protocol check ([`host::PROTOCOL`]; version → change
+//!   table in `tix-sdk/PROTOCOL.md`).
+//! - [`spawn`] — nested `tix` invocations pinned to the current ticket.
+//! - [`state`] — plugin state directories, created lazily.
+//! - [`SdkError`] — the SDK's error type; document parse/serialize errors
+//!   live here, not on the engine.
+//!
+//! `tix-engine` is re-exported wholesale (tokio/axum style): depend on
+//! `tix-sdk` alone and reach engine types as `tix_sdk::Ticket`,
+//! `tix_sdk::RepositoryConfig`, and so on. Frontends that want no tix
+//! layout policy may still depend on `tix-engine` directly.
+
+pub mod context;
+pub mod discovery;
+pub mod document;
+/// The SDK's error type.
+pub mod error;
+pub mod host;
+pub mod spawn;
+pub mod state;
+
+pub use error::SdkError;
+// Re-export the engine wholesale: the dependency chain is linear
+// ({tix-cli, pytix} → tix-sdk → tix-engine), and the re-export is what
+// makes lockstep versioning structurally true rather than conventional.
+pub use tix_engine::*;

--- a/tix-sdk/src/spawn.rs
+++ b/tix-sdk/src/spawn.rs
@@ -1,0 +1,47 @@
+//! Nested `tix` invocation helper (`design/spec.md` §5.5).
+//!
+//! A plugin may shell out to `tix`, but a nested host re-discovers from cwd
+//! — which the plugin may have changed — so nested `tix` can silently
+//! resolve a *different ticket*. Correct (cwd is the interface) but a
+//! footgun for authors who mean "same ticket". The supported path is
+//! skew-proof by construction: [`tix_command`] pins the current ticket.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Builds a `Command` for a nested `tix` invocation pinned to `ticket_root`.
+///
+/// The returned command already carries `--ticket <path>`, so it resolves
+/// the same ticket regardless of what cwd has become. Callers add their
+/// subcommand and args and spawn as usual.
+///
+/// The fork-bomb guard (`TIX_DEPTH`) is the *host's* job on dispatch —
+/// nothing to set here.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use std::path::Path;
+/// let mut command = tix_sdk::spawn::tix_command(Path::new("/home/user/tickets/JIRA-1"));
+/// command.args(["ticket", "info"]);
+/// let status = command.status().expect("tix not on PATH?");
+/// ```
+pub fn tix_command(ticket_root: &Path) -> Command {
+    let mut command = Command::new("tix");
+    command.arg("--ticket").arg(ticket_root);
+    command
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The pin rides at the front of the arg list.
+    #[test]
+    fn test_pins_ticket() {
+        let command = tix_command(Path::new("/tickets/JIRA-1"));
+        let args: Vec<_> = command.get_args().map(|a| a.to_string_lossy().to_string()).collect();
+        assert_eq!(args, vec!["--ticket", "/tickets/JIRA-1"]);
+        assert_eq!(command.get_program(), "tix");
+    }
+}

--- a/tix-sdk/src/state.rs
+++ b/tix-sdk/src/state.rs
@@ -1,0 +1,68 @@
+//! Plugin state directory helpers (`design/spec.md` §3.5).
+//!
+//! **State is not config.** Config is human-editable settings in a
+//! `[<plugin>]` table, read via section accessors and written via diff-back.
+//! State is caches and derived data of any shape or size: plain files in a
+//! directory, part of no document, no delta, and no protocol.
+//!
+//! Locations are SDK helpers, not contract flags — no env vars, no
+//! `--tix-*` flags. Consistency comes from every plugin calling the same
+//! helper, not from the host passing values. Directories are created
+//! **lazily, on first use** (v2 pre-created them every invocation, littering
+//! empty dirs for plugins that never stored anything).
+
+use crate::error::SdkError;
+use std::path::{Path, PathBuf};
+
+/// Per-ticket state directory: `<ticket_root>/.tix/plugins/<name>/`,
+/// created on call.
+///
+/// The only genuinely tix-shaped location — a plugin cannot locate a ticket
+/// without being told where it is (`--tix-ticket`).
+///
+/// # Errors
+///
+/// [`SdkError::Engine`]-wrapped IO error if creation fails.
+pub fn ticket_state_dir(ticket_root: &Path, plugin: &str) -> Result<PathBuf, SdkError> {
+    let dir = ticket_root.join(".tix").join("plugins").join(plugin);
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+/// Global cache directory for a plugin, from the platform cache location;
+/// created on call. Offered as convenience only — there is no consistency
+/// benefit to tix mediating what `dirs::cache_dir()` already names.
+///
+/// # Errors
+///
+/// [`SdkError::Message`] when the platform cache directory cannot be
+/// determined; IO errors if creation fails.
+pub fn cache_dir(plugin: &str) -> Result<PathBuf, SdkError> {
+    let base = dirs::cache_dir().ok_or_else(|| {
+        SdkError::Message("cannot determine the platform cache directory".to_string())
+    })?;
+    let dir = base.join("tix").join(plugin);
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// The per-ticket dir lands under .tix/plugins/<name> and is created
+    /// lazily — only when asked for.
+    #[test]
+    fn test_ticket_state_dir_lazy_creation() {
+        let root = tempdir().unwrap();
+        assert!(!root.path().join(".tix").exists());
+
+        let dir = ticket_state_dir(root.path(), "myplugin").unwrap();
+        assert_eq!(dir, root.path().join(".tix/plugins/myplugin"));
+        assert!(dir.is_dir());
+
+        // Idempotent.
+        assert_eq!(ticket_state_dir(root.path(), "myplugin").unwrap(), dir);
+    }
+}


### PR DESCRIPTION
Closes #96. Closes #67 — the atomic write path (sidecar-locked `with_write`, tmp+rename, concurrency test) now lives SDK-side where the issue moved it.

Stacked on #125 (base: `armaan/tix-update-84`).

**Promoted from tix-cli (tests included):** `context` (config path resolution), `discovery` (walk + `TicketRef`/`--ticket` semantics), `document` (format-preserving DOM, section accessors, atomic locked writes).

**New:**
- `host::HostContext` — `--tix-*` parsing (space/`=` forms), unknown-flag tolerance (capability detection for free), bare `print-cli-help` handled before any host flag, protocol check → exit **125** (`PROTOCOL = 1`, table in `tix-sdk/PROTOCOL.md`), `require_ticket()` for the optional-ticket contract
- `spawn::tix_command` — nested `tix` pinned to the current ticket
- `state` — lazily-created plugin state dirs
- `examples/toy-plugin.rs` — #96's done-when, verified: parses host flags, reads `[toy]`, exits 125 on mismatch, answers the handshake

**Breaking:**
- `tix-cli` depends on `tix-sdk` **only**; engine types arrive via wholesale re-export
- `SdkError` introduced; `ParseError`/`SerializationError`/`ConfigNotFound` leave `TixError`
- `tix-engine` runtime deps now `git2`/`serde`/`tracing` (toml → dev-dep, dirs dropped) — most of #59's dependency policy; the grep audit + contract comment follow as their own change

Workspace: 130 tests green (35 SDK / 52 engine / 43 CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)