### PR TITLE
docs(engine): document and enforce the no-IO contract

### DIFF
--- a/tix-engine/src/lib.rs
+++ b/tix-engine/src/lib.rs
@@ -6,6 +6,24 @@
 //! free of any UI concerns — all output, prompting, and formatting live in the
 //! frontends.
 //!
+//! # The engine contract
+//!
+//! This crate performs **domain operations over already-resolved paths** and
+//! nothing else (`design/spec.md` §2.2):
+//!
+//! - **Resolved paths in.** No discovery, no path resolution, no layout
+//!   policy — where config, tickets, and code live is frontend/SDK business
+//!   and must not leak in here.
+//! - **No ambient IO.** No env vars, no stdout/stderr, no process control.
+//!   Tracing macros (`info!`, `debug!`, …) are fine — they emit to whatever
+//!   subscriber the frontend wired up. Enforced by audit:
+//!   `grep -r "process::exit\|println!\|eprintln!\|env::var\|tracing_subscriber" src/`
+//!   must return nothing.
+//! - **Runtime dependencies are `git2`, `serde`, and `tracing` — only.**
+//!   No `clap` (arg parsing), no `dirs` (config location), no `toml`
+//!   (document parsing): those concerns are all SDK-side. `toml` appears as
+//!   a dev-dependency solely to round-trip test the serde section shapes.
+//!
 //! # Domain model
 //!
 //! - An [`EngineConfig`] is the `[engine]` section of the global config:

--- a/tix-engine/src/types/ticket.rs
+++ b/tix-engine/src/types/ticket.rs
@@ -119,9 +119,11 @@ impl TicketConfig {
     /// .unwrap();
     ///
     /// let ticket = config.resolve(PathBuf::from("/home/user/tickets/JIRA-123"))?;
-    /// for worktree in ticket.worktrees() {
-    ///     println!("{} → {}", worktree.name, worktree.branch);
-    /// }
+    /// let branches: Vec<&str> = ticket
+    ///     .worktrees()
+    ///     .iter()
+    ///     .map(|worktree| worktree.branch.as_str())
+    ///     .collect();
     /// # Ok(())
     /// # }
     /// ```
@@ -205,9 +207,7 @@ impl Ticket {
     /// # description = "Fix the login bug"
     /// # "#).unwrap();
     /// let ticket = config.resolve(PathBuf::from("/home/user/tickets/JIRA-123"))?;
-    /// for worktree in ticket.worktrees() {
-    ///     println!("{}", worktree.path.display());
-    /// }
+    /// let paths: Vec<_> = ticket.worktrees().iter().map(|w| &w.path).collect();
     /// # Ok(())
     /// # }
     /// ```


### PR DESCRIPTION
Closes #59

Stacked on #126 (base: `armaan/tix-sdk-96`).

Audit results (post-#96, all clean):
- `grep -r "process::exit\|println!\|eprintln!\|env::var\|tracing_subscriber" tix-engine/src/` → nothing (two doc-example `println!`s rephrased)
- `git.rs` still deleted; no `git2::Repository::clone` outside `RepositoryConfig`
- Runtime deps exactly `git2`/`serde`/`tracing`; `toml` dev-only; `dirs` gone; `ParseError` migrated to `SdkError` (both landed in #126)

Adds the contract block at the top of `lib.rs`, including the audit grep verbatim so it stays re-runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)