### PR TITLE
feat(cli,sdk): implement plugin dispatch with the invocation contract

### DIFF
--- a/tix-cli/src/main.rs
+++ b/tix-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod tix;
 
+use crate::tix::utils::App;
 use tix_sdk::context::Context;
 use crate::tix::{Commands, cli, config, plugin, repo, ticket};
 use tracing_subscriber::fmt;
@@ -34,39 +35,44 @@ fn main() {
     {
         fail(e);
     }
+    let app = App {
+        context,
+        output: parsed.output.unwrap_or(tix::utils::OutputType::Default),
+        log_level,
+    };
 
     let result = match parsed.command {
         Commands::Cli(args) => match args.command {
-            cli::CliCommands::Completions(args) => cli::completions::run(&context, args),
-            cli::CliCommands::Update(args) => cli::update::run(&context, args),
+            cli::CliCommands::Completions(args) => cli::completions::run(&app, args),
+            cli::CliCommands::Update(args) => cli::update::run(&app, args),
         },
         Commands::Config(args) => match args.command {
-            config::ConfigCommands::Get(args) => config::get::run(&context, args),
-            config::ConfigCommands::Init(args) => config::init::run(&context, args),
-            config::ConfigCommands::Set(args) => config::set::run(&context, args),
-            config::ConfigCommands::Show(args) => config::show::run(&context, args),
+            config::ConfigCommands::Get(args) => config::get::run(&app, args),
+            config::ConfigCommands::Init(args) => config::init::run(&app, args),
+            config::ConfigCommands::Set(args) => config::set::run(&app, args),
+            config::ConfigCommands::Show(args) => config::show::run(&app, args),
         },
         Commands::Repo(args) => match args.command {
-            repo::RepoCommands::Add(args) => repo::add::run(&context, args),
-            repo::RepoCommands::Clone(args) => repo::clone::run(&context, args),
+            repo::RepoCommands::Add(args) => repo::add::run(&app, args),
+            repo::RepoCommands::Clone(args) => repo::clone::run(&app, args),
         },
         Commands::Ticket(args) => match args.command {
-            ticket::TicketCommands::Add(args) => ticket::add::run(&context, args),
-            ticket::TicketCommands::Destroy(args) => ticket::destroy::run(&context, args),
-            ticket::TicketCommands::Info(args) => ticket::info::run(&context, args),
-            ticket::TicketCommands::List(args) => ticket::list::run(&context, args),
-            ticket::TicketCommands::Remove(args) => ticket::remove::run(&context, args),
-            ticket::TicketCommands::Setup(args) => ticket::setup::run(&context, args),
+            ticket::TicketCommands::Add(args) => ticket::add::run(&app, args),
+            ticket::TicketCommands::Destroy(args) => ticket::destroy::run(&app, args),
+            ticket::TicketCommands::Info(args) => ticket::info::run(&app, args),
+            ticket::TicketCommands::List(args) => ticket::list::run(&app, args),
+            ticket::TicketCommands::Remove(args) => ticket::remove::run(&app, args),
+            ticket::TicketCommands::Setup(args) => ticket::setup::run(&app, args),
         },
-        Commands::Add(args) => ticket::add::run(&context, args),
-        Commands::Destroy(args) => ticket::destroy::run(&context, args),
-        Commands::Info(args) => ticket::info::run(&context, args),
-        Commands::List(args) => ticket::list::run(&context, args),
-        Commands::Remove(args) => ticket::remove::run(&context, args),
-        Commands::Setup(args) => ticket::setup::run(&context, args),
-        Commands::Completions(args) => cli::completions::run(&context, args),
+        Commands::Add(args) => ticket::add::run(&app, args),
+        Commands::Destroy(args) => ticket::destroy::run(&app, args),
+        Commands::Info(args) => ticket::info::run(&app, args),
+        Commands::List(args) => ticket::list::run(&app, args),
+        Commands::Remove(args) => ticket::remove::run(&app, args),
+        Commands::Setup(args) => ticket::setup::run(&app, args),
+        Commands::Completions(args) => cli::completions::run(&app, args),
 
-        Commands::External(args) => plugin::run(&context, args),
+        Commands::External(args) => plugin::run(&app, args),
     };
 
     if let Err(e) = result {

--- a/tix-cli/src/tix/cli/completions.rs
+++ b/tix-cli/src/tix/cli/completions.rs
@@ -3,11 +3,10 @@
 //! Third-party plugin completions are not tix's problem: plugins are external
 //! binaries with their own interfaces.
 
-use tix_sdk::context::Context;
 use clap::CommandFactory;
 use tix_sdk::SdkError;
 
-/// Arguments for `tix completions`.
+/// Generate shell completions
 #[derive(clap::Args, Debug)]
 #[command(after_help = "\
 Installation:
@@ -25,7 +24,7 @@ pub struct Args {
 
 /// Generates completions from the clap command definition onto stdout — the
 /// user pipes them into their shell's completion path (see `--help`).
-pub fn run(_context: &Context, args: Args) -> Result<(), SdkError> {
+pub fn run(_app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
     let mut command = crate::tix::TixParser::command();
     clap_complete::generate(
         args.shell,

--- a/tix-cli/src/tix/cli/mod.rs
+++ b/tix-cli/src/tix/cli/mod.rs
@@ -5,6 +5,7 @@ pub mod update;
 
 use clap::{Args, Subcommand};
 
+/// Manage the tix CLI itself (update, completions)
 #[derive(Args)]
 pub struct CliArgs {
     #[command(subcommand)]

--- a/tix-cli/src/tix/cli/update.rs
+++ b/tix-cli/src/tix/cli/update.rs
@@ -5,7 +5,6 @@
 //! v2's self-updater, adjusted for the workspace and given `--dry-run` and
 //! checksum verification.
 
-use tix_sdk::context::Context;
 use semver::Version;
 use serde::Deserialize;
 use sha2::Digest;
@@ -19,7 +18,7 @@ const DEFAULT_OWNER: &str = "armaan-v924";
 const DEFAULT_REPO: &str = "tix";
 const USER_AGENT: &str = concat!("tix-updater/", env!("CARGO_PKG_VERSION"));
 
-/// Arguments for `tix update`.
+/// Update tix to the latest release
 #[derive(clap::Args, Debug)]
 pub struct Args {
     /// Print what would happen without downloading or writing anything
@@ -53,7 +52,7 @@ struct Target {
 /// `<asset>.sha256` sibling, the download is verified against it; releases
 /// without checksums skip verification. The binary is replaced via temp
 /// file + rename in its own directory.
-pub fn run(_context: &Context, args: Args) -> Result<(), SdkError> {
+pub fn run(_app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
     let target = detect_target()?;
     let owner = std::env::var("TIX_UPDATE_OWNER").unwrap_or_else(|_| DEFAULT_OWNER.into());
     let repo = std::env::var("TIX_UPDATE_REPO").unwrap_or_else(|_| DEFAULT_REPO.into());

--- a/tix-cli/src/tix/config/get.rs
+++ b/tix-cli/src/tix/config/get.rs
@@ -1,18 +1,13 @@
 //! `tix config get` — read value(s) from the `[cli]` section.
 
 use crate::tix::config::ConfigKey;
-use tix_sdk::context::Context;
 use tix_sdk::document::TixDocument;
 use crate::tix::utils::OutputType;
 use tix_sdk::SdkError;
 
-/// Arguments for `tix config get`.
+/// Read a value from the [cli] section
 #[derive(clap::Args, Debug)]
 pub struct Args {
-    /// Output format
-    #[arg(short, long)]
-    pub output: Option<OutputType>,
-
     /// The `[cli]` key(s) to read
     #[arg(required = true)]
     pub key: Vec<ConfigKey>,
@@ -24,8 +19,8 @@ pub struct Args {
 /// print `key = value` lines. Keys are validated at parse time by the
 /// [`ConfigKey`] value enum; a key that is valid but unset in the document
 /// errors here.
-pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
-    let document = TixDocument::load(&context.config_path)?;
+pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
+    let document = TixDocument::load(&app.context.config_path)?;
 
     let mut pairs = Vec::with_capacity(args.key.len());
     for key in &args.key {
@@ -37,13 +32,13 @@ pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
                 SdkError::Message(format!(
                     "'{}' is not set in [cli] (config: {})",
                     key.toml_key(),
-                    context.config_path.display()
+                    app.context.config_path.display()
                 ))
             })?;
         pairs.push((key.toml_key(), item.clone()));
     }
 
-    match args.output.unwrap_or(OutputType::Default) {
+    match app.output {
         OutputType::Default => {
             if let [(_, item)] = pairs.as_slice() {
                 println!("{}", render_bare(item));

--- a/tix-cli/src/tix/config/init.rs
+++ b/tix-cli/src/tix/config/init.rs
@@ -1,11 +1,10 @@
 //! `tix config init` — interactive first-time config creation.
 
-use tix_sdk::context::Context;
 use tix_sdk::document::TixDocument;
 use crate::tix::utils::prompt;
 use tix_sdk::SdkError;
 
-/// Arguments for `tix config init`.
+/// Create the global config interactively
 #[derive(clap::Args, Debug)]
 pub struct Args {
     /// Overwrite an existing config file
@@ -20,8 +19,8 @@ pub struct Args {
 /// uses (`--config` > `TIX_CONFIG_PATH` > platform default), which is why
 /// this command is exempt from the config-must-exist check. Parent
 /// directories are created; an existing file is refused without `--force`.
-pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
-    let path = &context.config_path;
+pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
+    let path = &app.context.config_path;
     if path.exists() && !args.force {
         return Err(SdkError::Message(format!(
             "config already exists at {} — pass --force to overwrite",

--- a/tix-cli/src/tix/config/mod.rs
+++ b/tix-cli/src/tix/config/mod.rs
@@ -59,6 +59,7 @@ impl ConfigKey {
     }
 }
 
+/// Manage the global tix config
 #[derive(Args)]
 pub struct ConfigArgs {
     #[command(subcommand)]

--- a/tix-cli/src/tix/config/set.rs
+++ b/tix-cli/src/tix/config/set.rs
@@ -2,11 +2,10 @@
 //! document layer.
 
 use crate::tix::config::{CliConfig, ConfigKey};
-use tix_sdk::context::Context;
 use tix_sdk::document::with_write;
 use tix_sdk::SdkError;
 
-/// Arguments for `tix config set`.
+/// Set a value in the [cli] section
 #[derive(clap::Args, Debug)]
 pub struct Args {
     /// The `[cli]` key to set
@@ -27,8 +26,8 @@ pub struct Args {
 ///
 /// The whole cycle runs under the exclusive advisory lock (#67), so
 /// concurrent `tix config set` invocations serialize rather than clobber.
-pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
-    with_write(&context.config_path, |document| {
+pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
+    with_write(&app.context.config_path, |document| {
         // `1` stays an integer, `true` a bool; anything that isn't valid
         // TOML (a bare path, say) is a string.
         let value: toml_edit::Value = args
@@ -53,7 +52,7 @@ pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
         "{} = {} ({})",
         args.key.toml_key(),
         args.value,
-        context.config_path.display()
+        app.context.config_path.display()
     );
     Ok(())
 }

--- a/tix-cli/src/tix/config/show.rs
+++ b/tix-cli/src/tix/config/show.rs
@@ -1,16 +1,12 @@
 //! `tix config show` — print the whole global config document.
 
-use tix_sdk::context::Context;
 use tix_sdk::document::TixDocument;
 use crate::tix::utils::OutputType;
 use tix_sdk::SdkError;
 
-/// Arguments for `tix config show`.
+/// Print the global config document
 #[derive(clap::Args, Debug)]
 pub struct Args {
-    /// Output format (default preserves the file as-is)
-    #[arg(short, long)]
-    pub output: Option<OutputType>,
 }
 
 /// Prints the global config document.
@@ -19,9 +15,9 @@ pub struct Args {
 /// comments, formatting, and plugin tables preserved, straight from the
 /// format-preserving DOM. JSON output converts the document's *values*
 /// (comments cannot survive a format that has none).
-pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
-    let document = TixDocument::load(&context.config_path)?;
-    match args.output.unwrap_or(OutputType::Default) {
+pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
+    let document = TixDocument::load(&app.context.config_path)?;
+    match app.output {
         OutputType::Default | OutputType::Toml => print!("{document}"),
         OutputType::Json => {
             let value: toml::Value = toml::from_str(&document.to_string())?;

--- a/tix-cli/src/tix/mod.rs
+++ b/tix-cli/src/tix/mod.rs
@@ -22,6 +22,11 @@ pub struct TixParser {
     #[arg(long, global = true, value_hint = clap::ValueHint::FilePath)]
     pub config: Option<PathBuf>,
 
+    /// Output format for commands that support it (also forwarded to
+    /// plugins as --tix-output)
+    #[arg(short, long, global = true)]
+    pub output: Option<crate::tix::utils::OutputType>,
+
     /// Set the log level (trace, debug, info, warn, error)
     #[arg(long, global = true)]
     pub log_level: Option<tracing::Level>,
@@ -94,7 +99,7 @@ fn root_help_requested() -> bool {
             "help" => return args.peek().is_none(),
             // Global flags (and their values) may precede the subcommand.
             "-v" | "--verbose" | "-q" | "--quiet" => continue,
-            "--log-level" | "--config" => {
+            "--log-level" | "--config" | "-o" | "--output" => {
                 args.next();
             }
             _ => return false,

--- a/tix-cli/src/tix/plugin.rs
+++ b/tix-cli/src/tix/plugin.rs
@@ -1,7 +1,193 @@
-use tix_sdk::context::Context;
-use tix_sdk::SdkError;
+//! Plugin dispatch: exec `tix-<name>` with the invocation contract
+//! (`design/spec.md` §5).
+//!
+//! Unknown subcommands land here via the clap catch-all — builtins always
+//! win, so dispatch is only ever reached for non-builtin names. There is no
+//! plugin registry: `PATH` is the registry.
 
-pub fn run(_context: &Context, args: Vec<String>) -> Result<(), SdkError> {
-    println!("{:#?}", args);
-    Ok(())
+use crate::tix::utils::App;
+use std::io::IsTerminal;
+use std::path::PathBuf;
+use tix_sdk::host::{PROTOCOL, PROTOCOL_MISMATCH_EXIT, prescan_globals};
+use tix_sdk::{SdkError, TicketConfig};
+use tracing::{debug, warn};
+
+/// Recursion guard: `tix-foo` shelling `tix foo` forever is the one failure
+/// mode that damages more than tix (spec §5.5).
+const DEPTH_ENV: &str = "TIX_DEPTH";
+const DEPTH_CAP: u32 = 10;
+
+/// Dispatches `tix <name> <args…>` to the `tix-<name>` binary on `PATH`.
+///
+/// The host resolves its own globals **before** forwarding — the raw args
+/// are pre-scanned (spec §5.3, the same SDK code plugins build on) and the
+/// plugin receives settled `--tix-*` values, never raw flags. stdin/stdout/
+/// stderr are inherited: the plugin owns the terminal. The child's exit code
+/// propagates unmodified, except **125**, which is reserved for protocol
+/// mismatch and reported as a versioning problem instead.
+///
+/// On exit 0 the `--tix-delta` file is handed to the diff-back apply path;
+/// a nonzero exit discards it.
+pub fn run(app: &App, args: Vec<String>) -> Result<(), SdkError> {
+    let mut args = args.into_iter();
+    let name = args
+        .next()
+        .ok_or_else(|| SdkError::Message("no plugin name in external args".to_string()))?;
+    let raw_args: Vec<String> = args.collect();
+
+    let Some(binary) = find_plugin(&name) else {
+        return Err(SdkError::Message(format!(
+            "unknown command '{name}': not a builtin, and no 'tix-{name}' executable on PATH"
+        )));
+    };
+
+    // Fork-bomb guard: increment TIX_DEPTH, hard-fail past the cap.
+    let depth: u32 = std::env::var(DEPTH_ENV)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(0);
+    if depth >= DEPTH_CAP {
+        return Err(SdkError::Message(format!(
+            "tix invocation depth {depth} exceeds the cap of {DEPTH_CAP} — \
+             a plugin is probably re-invoking itself"
+        )));
+    }
+
+    // Pre-scan the raw args for tix's own globals (external_subcommand
+    // captured them raw), then settle values for forwarding.
+    let (globals, user_args) = prescan_globals(&raw_args);
+    let log_level = globals
+        .log_level
+        .or_else(|| globals.verbose.then(|| "trace".to_string()))
+        .or_else(|| globals.quiet.then(|| "warn".to_string()))
+        .unwrap_or_else(|| app.log_level.to_string().to_lowercase());
+    let output = globals
+        .output
+        .unwrap_or_else(|| app.output.as_str().to_string());
+    // Per-process color resolution: the plugin's stdout is ours (inherited).
+    let color = std::env::var_os("NO_COLOR").is_none() && std::io::stdout().is_terminal();
+
+    // Ticket context from the discovery walk; its absence is forwarded as an
+    // absent flag, which is load-bearing (setup-shaped plugins run without).
+    let ticket_root = tix_sdk::discovery::discover_ticket_root()?;
+    let repo_context = ticket_root
+        .as_deref()
+        .and_then(|root| detect_current_repo(root).transpose())
+        .transpose()?;
+
+    // Host-created temp file for the outbound delta (spec §5.2). Kept alive
+    // until after the wait; deleted on drop.
+    let delta_file = tempfile::NamedTempFile::new().map_err(SdkError::from)?;
+
+    let mut command = std::process::Command::new(&binary);
+    command
+        .arg("--tix-protocol")
+        .arg(PROTOCOL.to_string())
+        .arg("--tix-config")
+        .arg(&app.context.config_path)
+        .arg("--tix-delta")
+        .arg(delta_file.path())
+        .arg("--tix-log-level")
+        .arg(&log_level)
+        .arg("--tix-output")
+        .arg(&output)
+        .arg("--tix-color")
+        .arg(color.to_string())
+        .env(DEPTH_ENV, (depth + 1).to_string());
+    if let Some(root) = &ticket_root {
+        command.arg("--tix-ticket").arg(root);
+    }
+    if let Some((alias, path)) = &repo_context {
+        command.arg("--tix-repo").arg(alias);
+        command.arg("--tix-repo-dir").arg(path);
+    }
+    command.args(&user_args);
+
+    debug!(plugin = %binary.display(), "dispatching");
+    let status = command.status().map_err(|e| {
+        SdkError::Message(format!("could not exec '{}': {e}", binary.display()))
+    })?;
+
+    match status.code() {
+        Some(0) => {
+            // Delta application is #98; the file's presence is detected here
+            // so the wiring is exercised.
+            let delta_bytes = std::fs::metadata(delta_file.path())
+                .map(|m| m.len())
+                .unwrap_or(0);
+            if delta_bytes > 0 {
+                debug!(bytes = delta_bytes, "plugin wrote a config delta; application lands with #98");
+            }
+            Ok(())
+        }
+        Some(PROTOCOL_MISMATCH_EXIT) => {
+            // Reserved: report a versioning problem, not a plugin crash, and
+            // keep 125 out of the propagated range.
+            Err(SdkError::Message(format!(
+                "plugin 'tix-{name}' speaks a different tix protocol (host speaks {PROTOCOL}) — \
+                 rebuild or update the plugin"
+            )))
+        }
+        Some(code) => {
+            // The plugin's error is the plugin's to report; tix adds nothing.
+            std::process::exit(code);
+        }
+        None => Err(SdkError::Message(format!(
+            "plugin 'tix-{name}' was terminated by a signal"
+        ))),
+    }
+}
+
+/// First `tix-<name>` executable on `PATH`, shell semantics.
+fn find_plugin(name: &str) -> Option<PathBuf> {
+    let binary_name = format!("tix-{name}");
+    std::env::split_paths(&std::env::var_os("PATH")?)
+        .map(|dir| dir.join(&binary_name))
+        .find(|candidate| is_executable(candidate))
+}
+
+/// Which repo worktree the cwd is inside, when it is inside one: the
+/// longest-prefix match of the logical cwd against `ticket_root/<name>` for
+/// every worktree the ticket tracks (v2's `detect_current_repo`).
+fn detect_current_repo(
+    ticket_root: &std::path::Path,
+) -> Result<Option<(String, PathBuf)>, SdkError> {
+    let document =
+        tix_sdk::document::TixDocument::load(&ticket_root.join(".tix").join("ticket.toml"))?;
+    let Some(ticket): Option<TicketConfig> = document.section("ticket")? else {
+        return Ok(None);
+    };
+    let cwd = tix_sdk::discovery::logical_cwd()?;
+
+    let mut best: Option<(String, PathBuf)> = None;
+    for name in ticket.worktrees.keys() {
+        let worktree_path = ticket_root.join(name);
+        let is_better = cwd.starts_with(&worktree_path)
+            && best
+                .as_ref()
+                .is_none_or(|(_, current)| worktree_path.components().count() > current.components().count());
+        if is_better {
+            best = Some((ticket.worktrees[name].repo.clone(), worktree_path));
+        }
+    }
+    Ok(best)
+}
+
+#[cfg(unix)]
+fn is_executable(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.metadata()
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &std::path::Path) -> bool {
+    path.is_file()
+}
+
+// Silence the unused warning until #98 wires the delta path in earnest.
+#[allow(dead_code)]
+fn _delta_placeholder() {
+    let _ = warn!("");
 }

--- a/tix-cli/src/tix/repo/add.rs
+++ b/tix-cli/src/tix/repo/add.rs
@@ -2,13 +2,12 @@
 //! `tix repo clone` (#65).
 
 use crate::tix::config::CliConfig;
-use tix_sdk::context::Context;
 use tix_sdk::document::with_write;
 use crate::tix::repo::{RepoAlias, RepoRef};
 use crate::tix::ticket::load_cli_config;
 use tix_sdk::{Defaults, EngineConfig, SdkError};
 
-/// Arguments for `tix repo add`.
+/// Register a repository in config (without cloning)
 #[derive(clap::Args, Debug)]
 pub struct Args {
     /// Alias to register under (defaults to the repository name)
@@ -37,11 +36,11 @@ pub struct Args {
 /// `code_path` derives as `<code_directory>/<alias>`. The write goes through
 /// the format-preserving layer and revalidates `EngineConfig` before landing;
 /// re-adding an existing alias errors.
-pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
-    let cli: CliConfig = load_cli_config(context)?;
+pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
+    let cli: CliConfig = load_cli_config(&app.context)?;
 
     // Alias may come from the flag; otherwise it falls out of the parse.
-    let (remote, repo_name) = resolve_remote(&args.repo.0, args.owner.as_deref(), context)?;
+    let (remote, repo_name) = resolve_remote(&args.repo.0, args.owner.as_deref(), app)?;
     let alias = args
         .alias
         .as_ref()
@@ -49,7 +48,7 @@ pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
         .unwrap_or_else(|| repo_name.clone());
     let code_path = cli.code_directory.join(&alias);
 
-    with_write(&context.config_path, |document| {
+    with_write(&app.context.config_path, |document| {
         let existing: EngineConfig = document.section_or_default("engine")?;
         if existing.configured_repositories.contains_key(&alias) {
             return Err(SdkError::Message(format!(
@@ -77,7 +76,7 @@ pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
 fn resolve_remote(
     repo: &str,
     owner_flag: Option<&str>,
-    context: &Context,
+    app: &crate::tix::utils::App,
 ) -> Result<(String, String), SdkError> {
     // Full URL forms pass through untouched.
     if repo.contains("://") || (repo.contains('@') && repo.contains(':')) {
@@ -91,7 +90,7 @@ fn resolve_remote(
     }
 
     let defaults: Defaults =
-        tix_sdk::document::TixDocument::load(&context.config_path)?.section_or_default("defaults")?;
+        tix_sdk::document::TixDocument::load(&app.context.config_path)?.section_or_default("defaults")?;
     let base = defaults
         .github_base_url
         .unwrap_or_else(|| "https://github.com".to_string());

--- a/tix-cli/src/tix/repo/clone.rs
+++ b/tix-cli/src/tix/repo/clone.rs
@@ -1,12 +1,11 @@
 //! `tix repo clone` — clone registered repositories to their code paths.
 
-use tix_sdk::context::Context;
 use tix_sdk::document::TixDocument;
 use crate::tix::repo::RepoAlias;
 use tix_sdk::{SdkError, EngineConfig, TixError};
 use tracing::error;
 
-/// Arguments for `tix repo clone`.
+/// Clone registered repositories to their code paths
 #[derive(clap::Args, Debug)]
 #[group(required = true, multiple = false)]
 pub struct Args {
@@ -25,8 +24,8 @@ pub struct Args {
 /// The batch never aborts on one failure: every target is attempted, each
 /// outcome is reported on its own line, and the exit is nonzero if anything
 /// failed. Unknown aliases error up front listing the registered set.
-pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
-    let document = TixDocument::load(&context.config_path)?;
+pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
+    let document = TixDocument::load(&app.context.config_path)?;
     let engine: EngineConfig = document.section_or_default("engine")?;
 
     let mut registered: Vec<&str> = engine

--- a/tix-cli/src/tix/repo/mod.rs
+++ b/tix-cli/src/tix/repo/mod.rs
@@ -27,6 +27,7 @@ impl FromStr for RepoRef {
     }
 }
 
+/// Register and clone source repositories
 #[derive(Args)]
 pub struct RepoArgs {
     #[command(subcommand)]

--- a/tix-cli/src/tix/ticket/add.rs
+++ b/tix-cli/src/tix/ticket/add.rs
@@ -1,6 +1,5 @@
 //! `tix ticket add` — add repository worktrees to an existing ticket.
 
-use tix_sdk::context::Context;
 use tix_sdk::document::{TixDocument, with_write};
 use crate::tix::repo::RepoAlias;
 use crate::tix::ticket::{
@@ -9,7 +8,7 @@ use crate::tix::ticket::{
 use tix_sdk::{SdkError, Defaults, EngineConfig, TixError};
 use tracing::{error, info};
 
-/// Arguments for `tix ticket add`.
+/// Add repository worktrees to a ticket
 #[derive(clap::Args, Debug)]
 pub struct Args {
     #[command(flatten)]
@@ -38,11 +37,11 @@ pub struct Args {
 /// The ticket document is updated per successful worktree through the
 /// format-preserving layer, so plugin tables and comments in
 /// `.tix/ticket.toml` survive.
-pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
-    let root = require_ticket_root(context, args.shared.ticket.as_ref())?;
+pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
+    let root = require_ticket_root(&app.context, args.shared.ticket.as_ref())?;
     let ticket = load_ticket_config(&root)?;
 
-    let document = TixDocument::load(&context.config_path)?;
+    let document = TixDocument::load(&app.context.config_path)?;
     let engine: EngineConfig = document.section_or_default("engine")?;
     let defaults: Defaults = document.section_or_default("defaults")?;
 

--- a/tix-cli/src/tix/ticket/destroy.rs
+++ b/tix-cli/src/tix/ticket/destroy.rs
@@ -1,12 +1,11 @@
 //! `tix ticket destroy` — prune every worktree, then delete the ticket.
 
-use tix_sdk::context::Context;
 use tix_sdk::document::{TixDocument, with_write};
 use crate::tix::ticket::{TicketRef, TicketSharedArgs, load_ticket_config, require_ticket_root};
 use tix_sdk::{SdkError, EngineConfig, TixError, WorktreeConfig};
 use tracing::{info, warn};
 
-/// Arguments for `tix ticket destroy`.
+/// Destroy a ticket: prune its worktrees, delete its directory
 #[derive(clap::Args, Debug)]
 pub struct Args {
     #[command(flatten)]
@@ -37,12 +36,12 @@ pub struct Args {
 /// fails** — forced deletion means deleted. Whatever had to be left behind
 /// (e.g. stale registrations in the source repos) is warned about, with a
 /// pointer at `git worktree prune`.
-pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
+pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
     let selector = args.target.as_ref().or(args.shared.ticket.as_ref());
-    let root = require_ticket_root(context, selector)?;
+    let root = require_ticket_root(&app.context, selector)?;
     let ticket = load_ticket_config(&root)?;
 
-    let document = TixDocument::load(&context.config_path)?;
+    let document = TixDocument::load(&app.context.config_path)?;
     let engine: EngineConfig = document.section_or_default("engine")?;
 
     if !args.force {

--- a/tix-cli/src/tix/ticket/info.rs
+++ b/tix-cli/src/tix/ticket/info.rs
@@ -1,12 +1,11 @@
 //! `tix ticket info` — display a ticket's metadata and worktree table.
 
-use tix_sdk::context::Context;
 use crate::tix::ticket::{TicketSharedArgs, load_ticket_config, require_ticket_root};
 use crate::tix::utils::OutputType;
 use std::path::{Path, PathBuf};
 use tix_sdk::{SdkError, TicketConfig};
 
-/// Arguments for `tix ticket info`.
+/// Show a ticket's metadata and worktrees
 #[derive(clap::Args, Debug)]
 pub struct Args {
     #[command(flatten)]
@@ -70,8 +69,8 @@ impl WorktreeStatus {
 ///
 /// There is deliberately no single ticket branch to print: branches are
 /// per-worktree (spec §3.2).
-pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
-    let root = require_ticket_root(context, args.shared.ticket.as_ref())?;
+pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
+    let root = require_ticket_root(&app.context, args.shared.ticket.as_ref())?;
     let ticket: TicketConfig = load_ticket_config(&root)?;
 
     // Grouped by repo, then by name within a repo.
@@ -91,7 +90,7 @@ pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
         .collect();
     rows.sort_by(|a, b| a.repo.cmp(&b.repo).then(a.name.cmp(&b.name)));
 
-    match args.output.unwrap_or(OutputType::Default) {
+    match app.output {
         OutputType::Default => {
             if ticket.description.is_empty() {
                 println!("{}", ticket.key);

--- a/tix-cli/src/tix/ticket/list.rs
+++ b/tix-cli/src/tix/ticket/list.rs
@@ -1,13 +1,12 @@
 //! `tix ticket list` — one line per ticket under the tickets directory.
 
-use tix_sdk::context::Context;
 use tix_sdk::document::TixDocument;
 use crate::tix::ticket::load_cli_config;
 use crate::tix::utils::OutputType;
 use tix_sdk::{SdkError, TicketConfig};
 use tracing::warn;
 
-/// Arguments for `tix ticket list`.
+/// List all tickets in the tickets directory
 #[derive(clap::Args, Debug)]
 pub struct Args {
     /// Output format
@@ -22,15 +21,15 @@ pub struct Args {
 /// layout is frontend policy; the engine is never involved). Directories
 /// without a `.tix/ticket.toml` are silently skipped; one with a malformed
 /// document warns and is skipped — a broken ticket never breaks the listing.
-pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
-    let cli = load_cli_config(context)?;
+pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
+    let cli = load_cli_config(&app.context)?;
 
     let mut tickets: Vec<TicketConfig> = Vec::new();
     let entries = match std::fs::read_dir(&cli.tickets_directory) {
         Ok(entries) => entries,
         Err(_) => {
             // No tickets directory yet simply means no tickets.
-            print_tickets(&tickets, args.output.unwrap_or(OutputType::Default))?;
+            print_tickets(&tickets, app.output)?;
             return Ok(());
         }
     };
@@ -49,7 +48,7 @@ pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
     }
     tickets.sort_by(|a, b| a.key.cmp(&b.key));
 
-    print_tickets(&tickets, args.output.unwrap_or(OutputType::Default))?;
+    print_tickets(&tickets, app.output)?;
     Ok(())
 }
 

--- a/tix-cli/src/tix/ticket/mod.rs
+++ b/tix-cli/src/tix/ticket/mod.rs
@@ -162,6 +162,7 @@ pub fn require_ticket_root(
     })
 }
 
+/// Create, inspect, and manage ticket workspaces
 #[derive(Args)]
 pub struct TicketArgs {
     #[command(subcommand)]

--- a/tix-cli/src/tix/ticket/remove.rs
+++ b/tix-cli/src/tix/ticket/remove.rs
@@ -1,13 +1,12 @@
 //! `tix ticket remove` — remove single worktrees from a ticket without
 //! destroying it.
 
-use tix_sdk::context::Context;
 use tix_sdk::document::{TixDocument, with_write};
 use crate::tix::ticket::{TicketSharedArgs, load_ticket_config, require_ticket_root};
 use tix_sdk::{SdkError, EngineConfig, TixError};
 use tracing::info;
 
-/// Arguments for `tix ticket remove`.
+/// Remove a worktree from a ticket without destroying it
 #[derive(clap::Args, Debug)]
 pub struct Args {
     #[command(flatten)]
@@ -30,11 +29,11 @@ pub struct Args {
 /// The ticket directory and every other worktree are untouched; removing
 /// the last worktree leaves a valid, empty ticket. Each successful prune is
 /// written back immediately through the format-preserving layer.
-pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
-    let root = require_ticket_root(context, args.shared.ticket.as_ref())?;
+pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
+    let root = require_ticket_root(&app.context, args.shared.ticket.as_ref())?;
     let ticket = load_ticket_config(&root)?;
 
-    let document = TixDocument::load(&context.config_path)?;
+    let document = TixDocument::load(&app.context.config_path)?;
     let engine: EngineConfig = document.section_or_default("engine")?;
 
     // Validate the batch up front: every name must be tracked, and every

--- a/tix-cli/src/tix/ticket/setup.rs
+++ b/tix-cli/src/tix/ticket/setup.rs
@@ -1,7 +1,6 @@
 //! `tix ticket setup` — create a new ticket workspace with worktrees.
 
 use crate::tix::config::CliConfig;
-use tix_sdk::context::Context;
 use tix_sdk::document::TixDocument;
 use crate::tix::repo::RepoAlias;
 use crate::tix::ticket::derive_branch_name;
@@ -10,7 +9,7 @@ use std::path::PathBuf;
 use tix_sdk::{SdkError, Defaults, EngineConfig, TicketConfig, TixError, WorktreeConfig};
 use tracing::{error, info};
 
-/// Arguments for `tix ticket setup`.
+/// Create a new ticket workspace with worktrees
 #[derive(clap::Args, Debug)]
 pub struct Args {
     /// The ticket key, e.g. JIRA-123 (a name, not a path)
@@ -42,7 +41,7 @@ pub struct Args {
 /// Partial failure leaves successfully created worktrees in place and
 /// records only them in `.tix/ticket.toml`; the command then errors naming
 /// the repos that failed.
-pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
+pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
     if args.key.is_empty() || args.key.contains(['/', '\\']) {
         return Err(SdkError::Message(format!(
             "'{}' is not a valid ticket key — keys are names, not paths (path-form creation is #114)",
@@ -50,7 +49,7 @@ pub fn run(context: &Context, args: Args) -> Result<(), SdkError> {
         )));
     }
 
-    let document = TixDocument::load(&context.config_path)?;
+    let document = TixDocument::load(&app.context.config_path)?;
     let cli: CliConfig = document.section("cli")?.ok_or_else(|| {
         SdkError::Message("global config has no [cli] section — run `tix config init`".to_string())
     })?;

--- a/tix-cli/src/tix/utils.rs
+++ b/tix-cli/src/tix/utils.rs
@@ -10,11 +10,35 @@ pub fn styles() -> Styles {
         .placeholder(AnsiColor::Cyan.on_default())
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, clap::ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum OutputType {
     Json,
     Toml,
     Default,
+}
+
+impl OutputType {
+    /// The value's wire form, as forwarded to plugins via `--tix-output`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            OutputType::Json => "json",
+            OutputType::Toml => "toml",
+            OutputType::Default => "default",
+        }
+    }
+}
+
+/// Everything a subcommand receives: the SDK context plus tix's resolved
+/// presentation globals. The host resolves these once, up front — they are
+/// what plugin dispatch forwards as settled `--tix-*` values (#68).
+pub struct App {
+    /// The SDK context (resolved config path).
+    pub context: tix_sdk::context::Context,
+    /// The resolved global output format (`--output`, hoisted from
+    /// per-subcommand flags so `tix foo --json | jq` works through plugins).
+    pub output: OutputType,
+    /// The resolved log level.
+    pub log_level: tracing::Level,
 }
 
 /// Prompts on stderr and reads one line from stdin; an empty answer takes

--- a/tix-sdk/src/host.rs
+++ b/tix-sdk/src/host.rs
@@ -212,6 +212,89 @@ impl HostContext {
     }
 }
 
+/// Tix's own global flags, pre-scanned out of raw forwarded args.
+///
+/// `external_subcommand` captures everything after a plugin name raw, so
+/// `tix foo --verbose` leaves the parsed globals untouched (spec §5.3). The
+/// host pre-scans the raw args with this — the same code that defines the
+/// SDK's view of the contract — resolves settled values, and forwards those;
+/// the matched flags are consumed (they are tix's, not the plugin's).
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct PrescannedGlobals {
+    /// `-v` / `--verbose` seen.
+    pub verbose: bool,
+    /// `-q` / `--quiet` seen.
+    pub quiet: bool,
+    /// `--log-level <level>` value.
+    pub log_level: Option<String>,
+    /// `-o` / `--output <format>` value.
+    pub output: Option<String>,
+    /// `--config <path>` value.
+    pub config: Option<PathBuf>,
+}
+
+/// Splits raw forwarded args into tix's own globals and everything else.
+///
+/// Everything unmatched — including unknown flags — passes through in order
+/// as the plugin's user args.
+pub fn prescan_globals(args: &[String]) -> (PrescannedGlobals, Vec<String>) {
+    let mut globals = PrescannedGlobals::default();
+    let mut user_args = Vec::with_capacity(args.len());
+    let mut iter = args.iter().peekable();
+    while let Some(arg) = iter.next() {
+        let mut take_value = |inline: Option<&str>| -> Option<String> {
+            inline
+                .map(str::to_string)
+                .or_else(|| iter.next().map(String::clone))
+        };
+        match arg.split_once('=') {
+            _ if arg == "-v" || arg == "--verbose" => globals.verbose = true,
+            _ if arg == "-q" || arg == "--quiet" => globals.quiet = true,
+            Some(("--log-level", value)) => globals.log_level = Some(value.to_string()),
+            Some(("--output", value)) | Some(("-o", value)) => {
+                globals.output = Some(value.to_string())
+            }
+            Some(("--config", value)) => globals.config = Some(PathBuf::from(value)),
+            None if arg == "--log-level" => globals.log_level = take_value(None),
+            None if arg == "--output" || arg == "-o" => globals.output = take_value(None),
+            None if arg == "--config" => globals.config = take_value(None).map(PathBuf::from),
+            _ => user_args.push(arg.clone()),
+        }
+    }
+    (globals, user_args)
+}
+
+#[cfg(test)]
+mod prescan_tests {
+    use super::*;
+
+    /// Globals are pulled out wherever they appear; the rest passes through
+    /// in order.
+    #[test]
+    fn test_prescan_extracts_globals() {
+        let args: Vec<String> = ["deploy", "--verbose", "--output", "json", "target", "--force"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (globals, user_args) = prescan_globals(&args);
+        assert!(globals.verbose);
+        assert_eq!(globals.output.as_deref(), Some("json"));
+        assert_eq!(user_args, vec!["deploy", "target", "--force"]);
+    }
+
+    /// Unknown flags are the plugin's business.
+    #[test]
+    fn test_prescan_leaves_unknown_flags() {
+        let args: Vec<String> = ["--frobnicate", "--log-level=debug"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (globals, user_args) = prescan_globals(&args);
+        assert_eq!(globals.log_level.as_deref(), Some("debug"));
+        assert_eq!(user_args, vec!["--frobnicate"]);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Closes #68

Stacked on #127 (base: `armaan/engine-audit-59`).

- `Commands::External` → find `tix-<name>` on PATH (first wins) or a clear unknown-command error
- **Pre-scan** (spec §5.3) lives in `tix_sdk::host::prescan_globals` — the same crate plugins build on; matched globals are consumed, the rest forwards untouched; unit-tested
- Prerequisite: `OutputType` hoisted to a global `-o/--output` on `TixParser` (per-subcommand flags removed), carried in a new `App` (SDK context + resolved output/log level) all subcommands receive
- Injected settled flags: protocol, config, delta temp file, ticket (discovery walk; absent when outside), repo/repo-dir (longest-prefix cwd match against tracked worktrees), log-level, output, color (`NO_COLOR` + TTY, per-process)
- `TIX_DEPTH` cap 10; inherited stdio; exit code propagated unmodified except reserved **125** → reported as a versioning problem; exit 0 detects the delta file and hands toward #98
- **Help polish** (Armaan's mid-session ask): every subcommand `about` rewritten user-facing — `tix --help` now reads "Add repository worktrees to a ticket", not "Arguments for `tix ticket add`"

Verified e2e with fixture plugins: full flag set inside a worktree (ticket+repo context), ticket-root-only (no repo flags), exit-7 propagation, 125 reporting, depth cap, unknown command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)