### PR TITLE
feat(sdk,cli): implement diff-back config delta application

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,6 +1259,7 @@ version = "3.0.0"
 dependencies = [
  "dirs",
  "serde",
+ "serde_json",
  "tempfile",
  "tix-engine",
  "toml",

--- a/tix-cli/src/tix/plugin.rs
+++ b/tix-cli/src/tix/plugin.rs
@@ -5,12 +5,15 @@
 //! win, so dispatch is only ever reached for non-builtin names. There is no
 //! plugin registry: `PATH` is the registry.
 
+use crate::tix::config::CliConfig;
 use crate::tix::utils::App;
 use std::io::IsTerminal;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use tix_sdk::delta::{Delta, DeltaTarget};
+use tix_sdk::document::with_write;
 use tix_sdk::host::{PROTOCOL, PROTOCOL_MISMATCH_EXIT, prescan_globals};
-use tix_sdk::{SdkError, TicketConfig};
-use tracing::{debug, warn};
+use tix_sdk::{Defaults, EngineConfig, SdkError, TicketConfig};
+use tracing::debug;
 
 /// Recursion guard: `tix-foo` shelling `tix foo` forever is the one failure
 /// mode that damages more than tix (spec §5.5).
@@ -109,17 +112,9 @@ pub fn run(app: &App, args: Vec<String>) -> Result<(), SdkError> {
     })?;
 
     match status.code() {
-        Some(0) => {
-            // Delta application is #98; the file's presence is detected here
-            // so the wiring is exercised.
-            let delta_bytes = std::fs::metadata(delta_file.path())
-                .map(|m| m.len())
-                .unwrap_or(0);
-            if delta_bytes > 0 {
-                debug!(bytes = delta_bytes, "plugin wrote a config delta; application lands with #98");
-            }
-            Ok(())
-        }
+        // The delta is applied only on exit 0; a failed plugin's
+        // half-intended writes are discarded with the temp file.
+        Some(0) => apply_delta_if_present(app, delta_file.path(), ticket_root.as_deref()),
         Some(PROTOCOL_MISMATCH_EXIT) => {
             // Reserved: report a versioning problem, not a plugin crash, and
             // keep 125 out of the propagated range.
@@ -186,8 +181,61 @@ fn is_executable(path: &std::path::Path) -> bool {
     path.is_file()
 }
 
-// Silence the unused warning until #98 wires the delta path in earnest.
-#[allow(dead_code)]
-fn _delta_placeholder() {
-    let _ = warn!("");
+/// Applies the plugin's outbound delta, if it wrote one (spec §6).
+///
+/// The apply happens against a **fresh parse at apply time** under the
+/// exclusive lock — never the host's startup snapshot — so it merges with
+/// whatever a nested `tix` or a second terminal wrote meanwhile. After the
+/// ops land, the host re-deserializes the sections it has types for:
+/// a delta that breaks a host-owned section ([engine]/[cli]/[defaults] or
+/// [ticket]) is rejected wholesale and nothing is written. Plugin sections
+/// pass unvalidated — the host has no schema for them, and the plugin
+/// validated its own on the way in. Writes outside the plugin's own section
+/// are allowed, unsupported: applied if revalidation passes.
+fn apply_delta_if_present(
+    app: &App,
+    delta_path: &Path,
+    ticket_root: Option<&Path>,
+) -> Result<(), SdkError> {
+    // No file written (or nothing in it) means no changes.
+    let bytes = std::fs::read(delta_path).unwrap_or_default();
+    if bytes.is_empty() {
+        return Ok(());
+    }
+
+    let delta = Delta::parse(&bytes)?;
+    let target_path = match delta.target {
+        DeltaTarget::Global => app.context.config_path.clone(),
+        DeltaTarget::Ticket => ticket_root
+            .ok_or_else(|| {
+                SdkError::PluginImplementation(
+                    "delta targets the ticket document, but the plugin ran outside a ticket"
+                        .to_string(),
+                )
+            })?
+            .join(".tix")
+            .join("ticket.toml"),
+    };
+
+    debug!(target = ?delta.target, ops = delta.ops.len(), "applying plugin delta");
+    with_write(&target_path, |document| {
+        delta.apply_ops(document)?;
+
+        // Revalidate host-owned sections; reject the whole delta if any no
+        // longer parse. with_write discards on Err, so nothing is written.
+        let reject = |e: SdkError| {
+            SdkError::PluginImplementation(format!("delta breaks a host-owned section: {e}"))
+        };
+        match delta.target {
+            DeltaTarget::Global => {
+                document.section::<EngineConfig>("engine").map_err(reject)?;
+                document.section::<CliConfig>("cli").map_err(reject)?;
+                document.section::<Defaults>("defaults").map_err(reject)?;
+            }
+            DeltaTarget::Ticket => {
+                document.section::<TicketConfig>("ticket").map_err(reject)?;
+            }
+        }
+        Ok(())
+    })
 }

--- a/tix-sdk/Cargo.toml
+++ b/tix-sdk/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 dirs = "6.0.0"
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.151"
 tix-engine = { path = "../tix-engine" }
 toml = "1.1.2"
 toml_edit = { version = "0.25.13", features = ["serde"] }

--- a/tix-sdk/src/delta.rs
+++ b/tix-sdk/src/delta.rs
@@ -1,0 +1,356 @@
+//! Diff-back config deltas (`design/spec.md` §6).
+//!
+//! Diff-back exists **only** because config has a single-writer constraint —
+//! the host. It is not an RPC channel: everything else a plugin does
+//! (worktrees, syncing, resolution) goes directly through `tix-sdk →
+//! tix-engine` in-process. A plugin that wants config changed writes a
+//! [`Delta`] into its `--tix-delta` file; the host applies it after a clean
+//! exit, against a **fresh parse** of the target document.
+//!
+//! Formats are asymmetric by design: inbound config is TOML (real files;
+//! `tomllib` is Python stdlib ≥3.11), the outbound delta is JSON (Python has
+//! no stdlib TOML *writer*). The JSON→TOML value mapping rides the JSON
+//! text form — `1` stays an integer, `1.0` a float — with one tagged escape
+//! hatch for the single inexpressible type:
+//! `{"$datetime": "2026-07-19T09:00:00Z"}`.
+
+use crate::document::TixDocument;
+use crate::error::SdkError;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Which document a delta targets. Exactly two exist, so no provenance
+/// tracking is needed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DeltaTarget {
+    /// The global config file.
+    Global,
+    /// The ticket document (`.tix/ticket.toml`).
+    Ticket,
+}
+
+/// One delta operation: put `value` at the dotted key path `set`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DeltaOp {
+    /// Dotted path into the target document, e.g. `myplugin.branch`.
+    pub set: String,
+    /// The value, in JSON. Mapped to TOML by text form at apply time.
+    pub value: serde_json::Value,
+}
+
+/// A config delta: a target document plus an ordered op list.
+///
+/// Ops are ordered; overlapping keys are last-writer-wins.
+///
+/// # Examples
+///
+/// The plugin side — build and write into the host's `--tix-delta` file:
+///
+/// ```no_run
+/// # use tix_sdk::delta::{Delta, DeltaTarget};
+/// # fn main() -> Result<(), tix_sdk::SdkError> {
+/// # let host = tix_sdk::host::HostContext::from_env()?;
+/// let delta = Delta::new(DeltaTarget::Ticket)
+///     .set("myplugin.branch", "main")?
+///     .set("myplugin.retries", 3)?;
+/// delta.write_to(host.delta_path.as_deref().expect("host always passes --tix-delta"))?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Delta {
+    /// The document the ops apply to.
+    pub target: DeltaTarget,
+    /// Ordered operations; overlapping keys last-writer-wins.
+    pub ops: Vec<DeltaOp>,
+}
+
+impl Delta {
+    /// An empty delta against `target`.
+    pub fn new(target: DeltaTarget) -> Self {
+        Self {
+            target,
+            ops: Vec::new(),
+        }
+    }
+
+    /// Appends a set op. `value` is anything serializable; typed datetimes
+    /// are the caller's job to tag (see [`Self::set_datetime`]).
+    ///
+    /// # Errors
+    ///
+    /// [`SdkError::Message`] if `value` does not serialize to JSON.
+    pub fn set(mut self, path: &str, value: impl Serialize) -> Result<Self, SdkError> {
+        let value = serde_json::to_value(value)
+            .map_err(|e| SdkError::Message(format!("unserializable delta value: {e}")))?;
+        self.ops.push(DeltaOp {
+            set: path.to_string(),
+            value,
+        });
+        Ok(self)
+    }
+
+    /// Appends a set op whose value is a TOML datetime, using the tagged
+    /// form (`{"$datetime": …}`) — the one type JSON cannot express.
+    pub fn set_datetime(mut self, path: &str, datetime: &str) -> Self {
+        self.ops.push(DeltaOp {
+            set: path.to_string(),
+            value: serde_json::json!({ "$datetime": datetime }),
+        });
+        self
+    }
+
+    /// Serializes into the `--tix-delta` file. No file written ⇒ no changes,
+    /// so plugins with nothing to say simply never call this.
+    ///
+    /// # Errors
+    ///
+    /// IO errors from the write.
+    pub fn write_to(&self, path: &Path) -> Result<(), SdkError> {
+        let json = serde_json::to_string(self)
+            .map_err(|e| SdkError::Message(format!("could not serialize delta: {e}")))?;
+        std::fs::write(path, json)?;
+        Ok(())
+    }
+
+    /// Parses a delta the host read back from the `--tix-delta` file.
+    ///
+    /// # Errors
+    ///
+    /// [`SdkError::PluginImplementation`] — a malformed delta is a bug in
+    /// the plugin, reported as such, and nothing gets written.
+    pub fn parse(bytes: &[u8]) -> Result<Self, SdkError> {
+        serde_json::from_slice(bytes).map_err(|e| {
+            SdkError::PluginImplementation(format!("malformed config delta: {e}"))
+        })
+    }
+
+    /// Applies every op to `document` as path traversals over the
+    /// format-preserving DOM.
+    ///
+    /// The host **never deserializes plugin tables** — a typed round-trip
+    /// would strip every `[<plugin>]` table plus comments (spec §6.2). Ops
+    /// navigate to the dotted path, creating intermediate tables as needed,
+    /// and put the mapped value there; untouched subtrees are never
+    /// interpreted. Ordered application makes overlapping keys
+    /// last-writer-wins.
+    ///
+    /// Revalidation of host-owned sections is the caller's job — the host
+    /// has the types, this module has the mechanics.
+    ///
+    /// # Errors
+    ///
+    /// [`SdkError::PluginImplementation`] for an empty path or an
+    /// unmappable value.
+    pub fn apply_ops(&self, document: &mut TixDocument) -> Result<(), SdkError> {
+        for op in &self.ops {
+            let segments: Vec<&str> = op.set.split('.').collect();
+            if segments.iter().any(|segment| segment.is_empty()) {
+                return Err(SdkError::PluginImplementation(format!(
+                    "empty path segment in delta op '{}'",
+                    op.set
+                )));
+            }
+            let (leaf, tables) = segments.split_last().expect("split never yields empty");
+
+            let mut item: &mut toml_edit::Item = document.doc_mut().as_item_mut();
+            for segment in tables {
+                let child = &mut item[*segment];
+                if child.is_none() {
+                    // Materialize missing levels as real tables (marked
+                    // implicit so empty intermediates render no header) —
+                    // bare indexing would produce an inline `a = { … }`
+                    // dotted at the top of the document instead of an
+                    // appended [a] section.
+                    let mut table = toml_edit::Table::new();
+                    table.set_implicit(true);
+                    *child = toml_edit::Item::Table(table);
+                }
+                item = child;
+            }
+            item[leaf] = toml_edit::Item::Value(json_to_toml_value(&op.value, &op.set)?);
+        }
+        Ok(())
+    }
+}
+
+/// Maps a JSON value to a TOML value by its text form: `1` → integer,
+/// `1.0` → float, string/bool direct, arrays and objects recurse, and the
+/// tagged `{"$datetime": "…"}` form becomes a native TOML datetime.
+fn json_to_toml_value(
+    value: &serde_json::Value,
+    path: &str,
+) -> Result<toml_edit::Value, SdkError> {
+    use serde_json::Value as Json;
+    Ok(match value {
+        Json::String(s) => toml_edit::Value::from(s.as_str()),
+        Json::Bool(b) => toml_edit::Value::from(*b),
+        // serde_json preserves the JSON text distinction: is_i64 for `1`,
+        // f64 for `1.0`.
+        Json::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                toml_edit::Value::from(i)
+            } else if let Some(f) = n.as_f64() {
+                toml_edit::Value::from(f)
+            } else {
+                return Err(SdkError::PluginImplementation(format!(
+                    "unrepresentable number {n} in delta op '{path}'"
+                )));
+            }
+        }
+        Json::Array(items) => {
+            let mut array = toml_edit::Array::new();
+            for item in items {
+                array.push(json_to_toml_value(item, path)?);
+            }
+            toml_edit::Value::Array(array)
+        }
+        Json::Object(map) => {
+            // The one tagged form: a single-key {"$datetime": "..."} object.
+            if let Some(Json::String(datetime)) = map.get("$datetime")
+                && map.len() == 1
+            {
+                let parsed: toml_edit::Datetime = datetime.parse().map_err(|e| {
+                    SdkError::PluginImplementation(format!(
+                        "invalid $datetime '{datetime}' in delta op '{path}': {e}"
+                    ))
+                })?;
+                toml_edit::Value::from(parsed)
+            } else {
+                let mut table = toml_edit::InlineTable::new();
+                for (key, item) in map {
+                    table.insert(key, json_to_toml_value(item, path)?);
+                }
+                toml_edit::Value::InlineTable(table)
+            }
+        }
+        Json::Null => {
+            return Err(SdkError::PluginImplementation(format!(
+                "null is not representable in TOML (delta op '{path}')"
+            )));
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The round-trip a plugin performs: build → write → parse.
+    #[test]
+    fn test_write_parse_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("delta.json");
+        let delta = Delta::new(DeltaTarget::Ticket)
+            .set("myplugin.branch", "main")
+            .unwrap()
+            .set("myplugin.retries", 3)
+            .unwrap();
+        delta.write_to(&path).unwrap();
+
+        let parsed = Delta::parse(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(parsed, delta);
+    }
+
+    /// The wire format matches the spec example.
+    #[test]
+    fn test_wire_format() {
+        let delta = Delta::new(DeltaTarget::Ticket)
+            .set("myplugin.branch", "main")
+            .unwrap();
+        assert_eq!(
+            serde_json::to_string(&delta).unwrap(),
+            r#"{"target":"ticket","ops":[{"set":"myplugin.branch","value":"main"}]}"#
+        );
+    }
+
+    /// JSON text form drives the TOML type: 1 integer, 1.0 float; datetime
+    /// via the tagged form; arrays and tables recurse.
+    #[test]
+    fn test_json_to_toml_mapping() {
+        let delta = Delta::parse(
+            br#"{"target":"global","ops":[
+                {"set":"p.int","value":1},
+                {"set":"p.float","value":1.0},
+                {"set":"p.text","value":"hi"},
+                {"set":"p.flag","value":true},
+                {"set":"p.list","value":[1,"two"]},
+                {"set":"p.table","value":{"a":1}},
+                {"set":"p.when","value":{"$datetime":"2026-07-19T09:00:00Z"}}
+            ]}"#,
+        )
+        .unwrap();
+        let mut document = TixDocument::empty();
+        delta.apply_ops(&mut document).unwrap();
+        let text = document.to_string();
+        assert!(text.contains("int = 1"), "{text}");
+        assert!(text.contains("float = 1.0"), "{text}");
+        assert!(text.contains(r#"text = "hi""#), "{text}");
+        assert!(text.contains("flag = true"), "{text}");
+        assert!(text.contains(r#"list = [1, "two"]"#), "{text}");
+        assert!(text.contains("when = 2026-07-19T09:00:00Z"), "{text}");
+    }
+
+    /// Applying against an existing document touches only the addressed
+    /// keys — comments and foreign tables survive.
+    #[test]
+    fn test_apply_preserves_untouched_content() {
+        let source = "# keep this comment\n[engine]\n\n[myplugin]\nbranch = \"old\" # inline\nkeep = 1\n";
+        let mut document = TixDocument::parse(source).unwrap();
+        let delta = Delta::new(DeltaTarget::Global)
+            .set("myplugin.branch", "new")
+            .unwrap();
+        delta.apply_ops(&mut document).unwrap();
+
+        let text = document.to_string();
+        assert!(text.contains("# keep this comment"));
+        assert!(text.contains("keep = 1"));
+        assert!(text.contains(r#"branch = "new""#));
+    }
+
+    /// A section created by a delta renders as an appended `[table]`, after
+    /// existing content — never an inline `a = { … }` at the document top.
+    #[test]
+    fn test_new_section_appends_as_table() {
+        let mut document = TixDocument::parse("[ticket]\nkey = \"JIRA-1\"\n").unwrap();
+        let delta = Delta::new(DeltaTarget::Ticket)
+            .set("myplugin.branch", "main")
+            .unwrap();
+        delta.apply_ops(&mut document).unwrap();
+        let text = document.to_string();
+        assert!(
+            text.starts_with("[ticket]"),
+            "existing content stays first:\n{text}"
+        );
+        assert!(text.contains("[myplugin]"), "header table form:\n{text}");
+    }
+
+    /// Overlapping keys are last-writer-wins, in op order.
+    #[test]
+    fn test_last_writer_wins() {
+        let mut document = TixDocument::empty();
+        let delta = Delta::new(DeltaTarget::Global)
+            .set("p.key", "first")
+            .unwrap()
+            .set("p.key", "second")
+            .unwrap();
+        delta.apply_ops(&mut document).unwrap();
+        assert!(document.to_string().contains(r#"key = "second""#));
+    }
+
+    /// Malformed JSON and unrepresentable values are plugin bugs.
+    #[test]
+    fn test_malformed_is_plugin_implementation_error() {
+        assert!(matches!(
+            Delta::parse(b"{not json"),
+            Err(SdkError::PluginImplementation(_))
+        ));
+        let delta = Delta::parse(br#"{"target":"global","ops":[{"set":"p.x","value":null}]}"#)
+            .unwrap();
+        assert!(matches!(
+            delta.apply_ops(&mut TixDocument::empty()),
+            Err(SdkError::PluginImplementation(_))
+        ));
+    }
+}

--- a/tix-sdk/src/error.rs
+++ b/tix-sdk/src/error.rs
@@ -22,6 +22,10 @@ pub enum SdkError {
     /// Migrated from the engine: config location is an SDK concern, and the
     /// engine never touches config paths.
     ConfigNotFound(String),
+    /// A plugin misused the invocation contract (malformed delta, broken
+    /// revalidation) — a bug in the plugin, not a tix failure, and nothing
+    /// was written.
+    PluginImplementation(String),
     /// A freeform SDK-level error message.
     Message(String),
 }
@@ -33,6 +37,11 @@ impl fmt::Display for SdkError {
             SdkError::Parse(e) => write!(f, "parse error: {}", e),
             SdkError::Serialization(e) => write!(f, "serialization error: {}", e),
             SdkError::ConfigNotFound(s) => write!(f, "config not found: {}", s),
+            SdkError::PluginImplementation(s) => write!(
+                f,
+                "plugin implementation error: {} — this is a bug in the plugin; nothing was written",
+                s
+            ),
             SdkError::Message(s) => write!(f, "{}", s),
         }
     }

--- a/tix-sdk/src/lib.rs
+++ b/tix-sdk/src/lib.rs
@@ -14,6 +14,8 @@
 //! - [`discovery`] — the ticket walk and `--ticket` override semantics.
 //! - [`document`] — the format-preserving TOML document layer: generic
 //!   parse, typed section extraction, atomic locked writes.
+//! - [`delta`] — diff-back config deltas: the plugin write helper and the
+//!   host's JSON→TOML apply mechanics.
 //! - [`host`] — the plugin side of the invocation contract: `--tix-*` flag
 //!   parsing and the protocol check ([`host::PROTOCOL`]; version → change
 //!   table in `tix-sdk/PROTOCOL.md`).
@@ -28,6 +30,7 @@
 //! layout policy may still depend on `tix-engine` directly.
 
 pub mod context;
+pub mod delta;
 pub mod discovery;
 pub mod document;
 /// The SDK's error type.


### PR DESCRIPTION
Closes #98

Stacked on #128 (base: `armaan/plugin-dispatch-68`).

**SDK (`tix_sdk::delta`)** — both sides of the wire:
- Plugin write helper: `Delta::new(target).set(path, value)` / `set_datetime` / `write_to`; wire format matches the spec example verbatim (tested)
- Apply mechanics: JSON→TOML by text form (`1`→int, `1.0`→float, recursion, `{"$datetime": …}`→TOML datetime, `null` rejected); path-traversal ops, last-writer-wins; new sections materialize as appended `[table]`s, never inline dotted keys
- New `SdkError::PluginImplementation` — malformed delta / broken revalidation is the plugin's bug, and nothing is written

**Host (dispatch, exit 0 only):**
- Fresh parse at apply time under the exclusive lock (`with_write`) — merges with concurrent writers, never the startup snapshot
- Revalidates host-owned sections (`[engine]`/`[cli]`/`[defaults]` global; `[ticket]` ticket); rejection is wholesale
- No file / empty file / nonzero exit ⇒ nothing written

All three "done when" clauses verified e2e with shell-script plugins: delta lands with all other content intact, exit-1 discards, `[engine]`-breaking delta rejected with the config file untouched. 46 SDK tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)