### PR TITLE
chore(lint): fix all clippy warnings across the workspace

### DIFF
--- a/pytix/src/lib.rs
+++ b/pytix/src/lib.rs
@@ -1,6 +1,6 @@
 use pyo3::prelude::*;
 
 #[pymodule]
-fn pytix(m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn pytix(_m: &Bound<'_, PyModule>) -> PyResult<()> {
     Ok(())
 }

--- a/tix-cli/src/tix/cli/update.rs
+++ b/tix-cli/src/tix/cli/update.rs
@@ -275,6 +275,28 @@ fn install_destination(target: &Target) -> Result<PathBuf, SdkError> {
     Ok(parent.join(target.exe_name))
 }
 
+/// Replaces the binary: rename when possible (same filesystem — atomic),
+/// copy as the cross-device fallback; executable bit restored on unix.
+fn install_binary(src: &Path, dest: &Path) -> Result<(), SdkError> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(SdkError::from)?;
+    }
+    if dest.exists() {
+        warn!(dest = %dest.display(), "replacing existing binary");
+    }
+    std::fs::rename(src, dest).or_else(|_| {
+        std::fs::copy(src, dest).map(|_| ()).map_err(SdkError::from)
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dest, std::fs::Permissions::from_mode(0o755))
+            .map_err(SdkError::from)?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -327,26 +349,4 @@ mod tests {
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         );
     }
-}
-
-/// Replaces the binary: rename when possible (same filesystem — atomic),
-/// copy as the cross-device fallback; executable bit restored on unix.
-fn install_binary(src: &Path, dest: &Path) -> Result<(), SdkError> {
-    if let Some(parent) = dest.parent() {
-        std::fs::create_dir_all(parent).map_err(SdkError::from)?;
-    }
-    if dest.exists() {
-        warn!(dest = %dest.display(), "replacing existing binary");
-    }
-    std::fs::rename(src, dest).or_else(|_| {
-        std::fs::copy(src, dest).map(|_| ()).map_err(SdkError::from)
-    })?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(dest, std::fs::Permissions::from_mode(0o755))
-            .map_err(SdkError::from)?;
-    }
-    Ok(())
 }

--- a/tix-cli/src/tix/config/show.rs
+++ b/tix-cli/src/tix/config/show.rs
@@ -15,7 +15,7 @@ pub struct Args {
 /// comments, formatting, and plugin tables preserved, straight from the
 /// format-preserving DOM. JSON output converts the document's *values*
 /// (comments cannot survive a format that has none).
-pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
+pub fn run(app: &crate::tix::utils::App, _args: Args) -> Result<(), SdkError> {
     let document = TixDocument::load(&app.context.config_path)?;
     match app.output {
         OutputType::Default | OutputType::Toml => print!("{document}"),

--- a/tix-cli/src/tix/mod.rs
+++ b/tix-cli/src/tix/mod.rs
@@ -53,11 +53,10 @@ impl TixParser {
     /// top-level commands only.
     pub fn parse_with_plugin_help() -> Self {
         let mut command = TixParser::command();
-        if root_help_requested() {
-            if let Some(section) = plugin_listing::plugins_help_section() {
+        if root_help_requested()
+            && let Some(section) = plugin_listing::plugins_help_section() {
                 command = command.after_help(section);
             }
-        }
         let mut matches = command.get_matches();
         match TixParser::from_arg_matches_mut(&mut matches) {
             Ok(parsed) => parsed,

--- a/tix-cli/src/tix/ticket/list.rs
+++ b/tix-cli/src/tix/ticket/list.rs
@@ -21,7 +21,7 @@ pub struct Args {
 /// layout is frontend policy; the engine is never involved). Directories
 /// without a `.tix/ticket.toml` are silently skipped; one with a malformed
 /// document warns and is skipped — a broken ticket never breaks the listing.
-pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
+pub fn run(app: &crate::tix::utils::App, _args: Args) -> Result<(), SdkError> {
     let cli = load_cli_config(&app.context)?;
 
     let mut tickets: Vec<TicketConfig> = Vec::new();

--- a/tix-cli/src/tix/ticket/mod.rs
+++ b/tix-cli/src/tix/ticket/mod.rs
@@ -90,13 +90,11 @@ mod branch_name_tests {
     fn test_sanitization() {
         assert_eq!(sanitize_description("Fix: the (login) bug!!"), "fix-the-login-bug");
         assert_eq!(sanitize_description("---"), "");
-        assert_eq!(
+        assert!(
             sanitize_description(
                 "a very long description that goes on and on and on far past the cap"
             )
-            .len()
-                <= 40,
-            true
+            .len() <= 40
         );
     }
 

--- a/tix-engine/src/types/repository.rs
+++ b/tix-engine/src/types/repository.rs
@@ -592,7 +592,7 @@ mod tests {
             dir.path().join("remote").to_str().unwrap().into(),
             dir.path().join("local"),
         );
-        assert!(config.clone_remote("test".into()).is_ok());
+        assert!(config.clone_remote("test").is_ok());
     }
 
     /// An invalid/nonexistent remote URL returns `TixError::GitError`.
@@ -604,7 +604,7 @@ mod tests {
             dir.path().join("local"),
         );
         assert!(matches!(
-            config.clone_remote("test".into()),
+            config.clone_remote("test"),
             Err(TixError::GitError(_))
         ));
     }
@@ -620,7 +620,7 @@ mod tests {
             dir.path().join("remote").to_str().unwrap().into(),
             dir.path().join("local"),
         );
-        assert!(config.resolve("test".into()).is_ok());
+        assert!(config.resolve("test").is_ok());
     }
 
     /// A path that is not a git repository returns `TixError::GitError`.
@@ -628,7 +628,7 @@ mod tests {
     fn test_resolve_invalid_path() {
         let remote = "this/is/an/invalid/repo/dir";
         let dir = tempdir().unwrap();
-        let config = RepositoryConfig::new(remote.into(), dir.path().join("local").into());
+        let config = RepositoryConfig::new(remote.into(), dir.path().join("local"));
         assert!(matches!(config.resolve("test"), Err(TixError::GitError(_))));
     }
 

--- a/tix-sdk/src/host.rs
+++ b/tix-sdk/src/host.rs
@@ -245,7 +245,7 @@ pub fn prescan_globals(args: &[String]) -> (PrescannedGlobals, Vec<String>) {
         let mut take_value = |inline: Option<&str>| -> Option<String> {
             inline
                 .map(str::to_string)
-                .or_else(|| iter.next().map(String::clone))
+                .or_else(|| iter.next().cloned())
         };
         match arg.split_once('=') {
             _ if arg == "-v" || arg == "--verbose" => globals.verbose = true,


### PR DESCRIPTION
Stacked on #130 (base: `armaan/plugin-spec-87`) — tail of the stack.

`cargo clippy --workspace --all-targets` now reports **zero** warnings. All fixes mechanical (mostly `clippy --fix`): underscore-prefixed unused params, dropped redundant `.into()`s in engine tests, `map(String::clone)` → `cloned()`, collapsed the root-help `if`, `assert_eq!(_, true)` → `assert!`, and `install_binary` hoisted above the test module in update.rs. Full test suite unchanged and green (123 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)