### PR TITLE
chore: fix rustfmt drift and unused pytest import for green CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -68,12 +68,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "base64"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,9 +75,9 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -108,9 +102,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -126,9 +120,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -136,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -157,14 +151,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -225,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -246,9 +240,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "digest"
@@ -284,13 +275,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -320,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "filetime"
@@ -336,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
@@ -350,12 +341,6 @@ dependencies = [
  "miniz_oxide",
  "zlib-rs",
 ]
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -379,27 +364,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
+ "r-efi",
 ]
 
 [[package]]
@@ -412,15 +383,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
 ]
 
 [[package]]
@@ -462,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -476,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -489,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -503,16 +465,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -523,15 +486,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -541,12 +504,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
@@ -576,9 +533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
- "serde",
- "serde_core",
+ "hashbrown",
 ]
 
 [[package]]
@@ -595,11 +550,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -610,22 +565,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.5+1.9.4"
+version = "0.18.8+1.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
+checksum = "7f7c568b25d7489bc3fb2988ed69ab111d2944d2f5fec3d5c987fe545ea97b50"
 dependencies = [
  "cc",
  "libc",
@@ -635,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
@@ -662,9 +611,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "litrs"
@@ -674,9 +623,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "matchers"
@@ -689,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
@@ -750,21 +699,21 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -776,29 +725,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
  "libc",
  "once_cell",
@@ -810,18 +749,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -829,27 +768,26 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -862,18 +800,12 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -894,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -962,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1004,7 +936,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1087,9 +1019,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1098,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1115,7 +1047,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1142,7 +1074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1150,41 +1082,40 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -1194,15 +1125,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1210,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1269,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1308,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -1340,7 +1271,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1399,12 +1330,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -1498,58 +1423,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
 
 [[package]]
 name = "webpki-roots"
@@ -1650,112 +1523,18 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "xattr"
@@ -1786,7 +1565,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -1807,7 +1586,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -1819,9 +1598,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -1830,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -1841,13 +1620,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1872,9 +1651,9 @@ checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"

--- a/pytix/Cargo.toml
+++ b/pytix/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 tix-engine = { path = "../tix-engine" }
-pyo3 = { version = "0.28.3", features = ["abi3-py311"] }
+pyo3 = { version = "0.29.2", features = ["abi3-py311"] }

--- a/pytix/tests/test_stub.py
+++ b/pytix/tests/test_stub.py
@@ -1,5 +1,2 @@
-import pytest
-
-
 def test_stub():
     pass

--- a/pytix/uv.lock
+++ b/pytix/uv.lock
@@ -22,32 +22,32 @@ wheels = [
 
 [[package]]
 name = "maturin"
-version = "1.14.0"
+version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/d0/b7c8b7778cc44df3efbc96eb23acaa995e06ea1a60eb9b02f29858fcbd08/maturin-1.14.0.tar.gz", hash = "sha256:f7f82a6aca4a6c402bf00b99200be199d4874d04b9b9e74e825726a3478bba7f", size = 367010, upload-time = "2026-06-12T00:13:30.811Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/c8/22e5e21b2679c9bce6415ca578034ca2cc9316be0642ae21e051a2d5198c/maturin-1.15.0.tar.gz", hash = "sha256:94b26cc8e8aba61a5f2099715fe640e18c5f678e9a500408b38761263954228a", size = 385504, upload-time = "2026-08-24T12:11:22.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/51/49367dcd8f6ec139e69ef0c695c8ff5075223673382101812b4affa53216/maturin-1.14.0-py3-none-linux_armv6l.whl", hash = "sha256:019ea3ec7e71f4c9759a367d4d21022ed5a3a621a2ce123abf3fb114ab3711ca", size = 10204135, upload-time = "2026-06-12T00:13:34.308Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/2a/487ce56c838d25e0ce64350e75ec4e3dc89544c0a6233221c229d6aa1a84/maturin-1.14.0-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6948a10f5f3470b791f79319be51debdd8bfd1778b36f2409f98e1314bc3859b", size = 19736800, upload-time = "2026-06-12T00:13:40.456Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/a5/12f2efc18f419edce3282a93629cba16278bb502135dac95cd04ef7c2eae/maturin-1.14.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:1506e86b1e273a98074a62e281b13f27ac96f8cdef85f7f98d3e3589a9387a23", size = 10201144, upload-time = "2026-06-12T00:13:26.842Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/95/3789e72273fd8bc80c33a11c787634b3251c4989d7a7203a92438836d4ff/maturin-1.14.0-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:df10ce4f7ba97fd3423f624f39b94c888ae3e5b470642a91918e1ccec81282fd", size = 10182394, upload-time = "2026-06-12T00:13:13.693Z" },
-    { url = "https://files.pythonhosted.org/packages/40/79/15957eb4e055597f217e6310963a9c1371372e63c5b4a3e30803365addd2/maturin-1.14.0-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:75bcd4468a7fe597652cc2980c6bb16ce4bb8c411e3eb85dac2c4418cef0e95a", size = 10616603, upload-time = "2026-06-12T00:13:22.795Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/4b/d1822f88cd5e855640f0e10ee00c39b9be614c1ef2f827e9792332d94b9f/maturin-1.14.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:2d123337e817f8dfe23755d6760139c01104137bb63e9e20c289c547e25ec857", size = 10075309, upload-time = "2026-06-12T00:13:38.274Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/82/c1b160d2163e8784489285e82a5c811fdcef3e0704e35b34c1cfe1828de3/maturin-1.14.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:107f84110d890090a01bb1ecd01761fdfae925c23c659ba492c9b83dd179eab4", size = 10024058, upload-time = "2026-06-12T00:13:16.49Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e8/88a9d1872997d4535af10ebe79f550e834880bf613cf8e50b50d2d938e3b/maturin-1.14.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:9a84277aa907961cd47ad26fef1539e79efa30611972eaf7499606e773e991b2", size = 13302073, upload-time = "2026-06-12T00:13:29.027Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/13/3f6d28bb7b744558b9bc78c995c1855d7e5ff21ad475f46d9de5c3dab039/maturin-1.14.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:095714b2a904927e3c868a1c5d078257ff0443c5049f7623777352966768306e", size = 10863616, upload-time = "2026-06-12T00:13:32.191Z" },
-    { url = "https://files.pythonhosted.org/packages/24/06/39352d2b402efa3a7dd01d4ed197b301ea35eec10208ba2b8c649101f4df/maturin-1.14.0-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:20229d332f87166b930e4ca07cdbee8a1726f2eea87a337610aa25bba3ddf4b4", size = 10399943, upload-time = "2026-06-12T00:13:36.273Z" },
-    { url = "https://files.pythonhosted.org/packages/58/77/641504541336240fef3836b2d15a785eaeb33c941fb118513c267dd70840/maturin-1.14.0-py3-none-win32.whl", hash = "sha256:4ba1e3c3f33609f461d587b7549104c81a15fd6d42ba63a73cea9376a1e9876e", size = 8905117, upload-time = "2026-06-12T00:13:18.38Z" },
-    { url = "https://files.pythonhosted.org/packages/02/4a/ca247a0c43069b2f48cf783c5b13c3a9eb92c8f596dc7fbdb9f75fea4414/maturin-1.14.0-py3-none-win_amd64.whl", hash = "sha256:cb09a313f097adeb4dda0082277871a28d1bd26615dbadab42e6234b6df6fe69", size = 10309099, upload-time = "2026-06-12T00:13:20.523Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/a4/f14a3f6086cc3caaa90d12e832e4aa41de771c310041959f0d35dd4efe17/maturin-1.14.0-py3-none-win_arm64.whl", hash = "sha256:8c1a8188195f5b6ce1aab99ae2d92e342900298f901456b43ca028947fd3b288", size = 9719100, upload-time = "2026-06-12T00:13:24.741Z" },
+    { url = "https://files.pythonhosted.org/packages/14/69/5c01b461044eb1f45ddcce006706eb88110c793cdb11c7ae0b5e08492e94/maturin-1.15.0-py3-none-linux_armv6l.whl", hash = "sha256:6bf6dc62e22d4dcfd5a51244ff0d58975fa4979c48209fe84159617648956d82", size = 10206220, upload-time = "2026-08-24T12:10:53.327Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/1f/2b431554e11687cdb1077e0cdadcc118c53f611086b3af00c8545a67c6a5/maturin-1.15.0-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:cd35772633f489841132bc8e71d6fc7f842df30b9c05cd5cdf1ee1ddcb744cc7", size = 19416513, upload-time = "2026-08-24T12:10:56.126Z" },
+    { url = "https://files.pythonhosted.org/packages/51/36/e23a21cb34a648b711036b9b2fe1d4f3f4ee24f8db54215d73f1a9a3a3ec/maturin-1.15.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c40b4eae7bf5ef1f4b1af8d623fe4105016f93578fb15b764e741d08ec3b92dd", size = 10014962, upload-time = "2026-08-24T12:10:58.486Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/80/33b15cb2d8f30f12c807955e8f2fd775027692904e30ec0784744ce8cd83/maturin-1.15.0-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:7eb066372f541f8eb4909c79c5d9bd0b9e8125980bdf1ec9e8aba23c6c8d6c55", size = 10196223, upload-time = "2026-08-24T12:11:00.696Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/91/b495e19e2f5c503b540452b2039115e7b2363867e8c5ad4179eb752fa92c/maturin-1.15.0-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:653020a63525bb224e5ab0adf02e17a2e08bc86dbea7fc1399c9a56d7529b99e", size = 10541186, upload-time = "2026-08-24T12:11:02.857Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/2b/2abff58037188d852b124871b1f0d720e1c2bfb3d4f1b03d87c52cd66488/maturin-1.15.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:0ebf9767892725083138e671c34482c660317a2f3d6a29fc0e0f34e9d8c99136", size = 10083468, upload-time = "2026-08-24T12:11:05.012Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/07/b7e9f8be99a6627849e81ac7b6694876bce8f50a92995fe17e3cf2610f0a/maturin-1.15.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:7ab7eebffd7b8debca2265985de4eaeb332141276d24b9560b5ad484d4b3add1", size = 10047786, upload-time = "2026-08-24T12:11:07.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ab/167e3cb7accee11b507dbe53e0e87aeccb376d44ae66284c96ee4df3a9fd/maturin-1.15.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:126e12e618b4db42f68c779a56d41f82a390145ba36ac3f621d057eb34f5ad9d", size = 13315332, upload-time = "2026-08-24T12:11:09.433Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4d/801379f646cbc6b00998e5289b0630a886be3a4ee4c75b6bc9b87478a7f1/maturin-1.15.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4f9d33e6c3f9615c8caceecbbbd440f8eb25a3ddeb687077682cd5eca2e9ae15", size = 10807183, upload-time = "2026-08-24T12:11:11.73Z" },
+    { url = "https://files.pythonhosted.org/packages/89/27/2e612e1cbd1580e9e94d4722c227b5180dca27b32b955a34b79918aa1292/maturin-1.15.0-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:bf29beddd0c6708f112db51d5275fc28b28b9e9c9c5faae387eaef662918b176", size = 10413274, upload-time = "2026-08-24T12:11:14.04Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d8/202a7b4d75a51f20f84ec9ce3b7345b12b822207072164e2b1c6ef665125/maturin-1.15.0-py3-none-win32.whl", hash = "sha256:da649988be98e87e009e51b1bf0d301b6a301bc0cecbdd60d40d8ba60748d1ca", size = 8928744, upload-time = "2026-08-24T12:11:16.269Z" },
+    { url = "https://files.pythonhosted.org/packages/40/dc/4e90da594986ba78dd3bc8a5921ecdcdb11085b22b02a412caab3b225601/maturin-1.15.0-py3-none-win_amd64.whl", hash = "sha256:552c2be4afd43fe8d5c9f3ec8d4c4756d973b8dcbe94c14084390301f50243e1", size = 10335085, upload-time = "2026-08-24T12:11:18.326Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/10/15d4314edf130955edf2dc237aa393a8a7c10f2b9b57b89fa2f61f915659/maturin-1.15.0-py3-none-win_arm64.whl", hash = "sha256:c7dc0c66c78d3debdd9c5aa807e861fbcbf07f3505d34b125df74c03986b0f48", size = 9713795, upload-time = "2026-08-24T12:11:20.83Z" },
 ]
 
 [[package]]
 name = "packaging"
-version = "26.2"
+version = "26.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
 ]
 
 [[package]]
@@ -61,16 +61,16 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
 ]
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -79,9 +79,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]

--- a/tix-cli/src/main.rs
+++ b/tix-cli/src/main.rs
@@ -1,8 +1,8 @@
 mod tix;
 
 use crate::tix::utils::App;
-use tix_sdk::context::Context;
 use crate::tix::{Commands, cli, config, plugin, repo, ticket};
+use tix_sdk::context::Context;
 use tracing_subscriber::fmt;
 
 /// Prints a CLI error to stderr and exits nonzero.

--- a/tix-cli/src/tix/cli/update.rs
+++ b/tix-cli/src/tix/cli/update.rs
@@ -112,7 +112,10 @@ pub fn run(_app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
     let extracted = extract_archive(&archive_path, &target)?;
     install_binary(&extracted, &destination)?;
 
-    println!("updated tix {current} -> {latest} ({})", destination.display());
+    println!(
+        "updated tix {current} -> {latest} ({})",
+        destination.display()
+    );
     Ok(())
 }
 
@@ -284,9 +287,8 @@ fn install_binary(src: &Path, dest: &Path) -> Result<(), SdkError> {
     if dest.exists() {
         warn!(dest = %dest.display(), "replacing existing binary");
     }
-    std::fs::rename(src, dest).or_else(|_| {
-        std::fs::copy(src, dest).map(|_| ()).map_err(SdkError::from)
-    })?;
+    std::fs::rename(src, dest)
+        .or_else(|_| std::fs::copy(src, dest).map(|_| ()).map_err(SdkError::from))?;
 
     #[cfg(unix)]
     {
@@ -332,7 +334,10 @@ mod tests {
 
         let dest = dir.path().join("bin/tix");
         install_binary(&extracted, &dest).unwrap();
-        assert_eq!(std::fs::read_to_string(&dest).unwrap(), "#!/bin/sh\necho new\n");
+        assert_eq!(
+            std::fs::read_to_string(&dest).unwrap(),
+            "#!/bin/sh\necho new\n"
+        );
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;

--- a/tix-cli/src/tix/config/get.rs
+++ b/tix-cli/src/tix/config/get.rs
@@ -1,9 +1,9 @@
 //! `tix config get` — read value(s) from the `[cli]` section.
 
 use crate::tix::config::ConfigKey;
-use tix_sdk::document::TixDocument;
 use crate::tix::utils::OutputType;
 use tix_sdk::SdkError;
+use tix_sdk::document::TixDocument;
 
 /// Read a value from the [cli] section
 #[derive(clap::Args, Debug)]
@@ -76,6 +76,10 @@ fn render_bare(item: &toml_edit::Item) -> String {
 /// parse — handles every value shape without a hand-written mapping.
 fn item_to_json(key: &str, item: &toml_edit::Item) -> Result<serde_json::Value, SdkError> {
     let table: toml::Table = toml::from_str(&format!("{key} = {}", item.to_string().trim()))?;
-    let value = table.get(key).cloned().unwrap_or(toml::Value::String(String::new()));
-    serde_json::to_value(value).map_err(|e| SdkError::Message(format!("json conversion failed: {e}")))
+    let value = table
+        .get(key)
+        .cloned()
+        .unwrap_or(toml::Value::String(String::new()));
+    serde_json::to_value(value)
+        .map_err(|e| SdkError::Message(format!("json conversion failed: {e}")))
 }

--- a/tix-cli/src/tix/config/init.rs
+++ b/tix-cli/src/tix/config/init.rs
@@ -1,8 +1,8 @@
 //! `tix config init` — interactive first-time config creation.
 
-use tix_sdk::document::TixDocument;
 use crate::tix::utils::prompt;
 use tix_sdk::SdkError;
+use tix_sdk::document::TixDocument;
 
 /// Create the global config interactively
 #[derive(clap::Args, Debug)]

--- a/tix-cli/src/tix/config/set.rs
+++ b/tix-cli/src/tix/config/set.rs
@@ -2,8 +2,8 @@
 //! document layer.
 
 use crate::tix::config::{CliConfig, ConfigKey};
-use tix_sdk::document::with_write;
 use tix_sdk::SdkError;
+use tix_sdk::document::with_write;
 
 /// Set a value in the [cli] section
 #[derive(clap::Args, Debug)]

--- a/tix-cli/src/tix/config/show.rs
+++ b/tix-cli/src/tix/config/show.rs
@@ -1,13 +1,12 @@
 //! `tix config show` — print the whole global config document.
 
-use tix_sdk::document::TixDocument;
 use crate::tix::utils::OutputType;
 use tix_sdk::SdkError;
+use tix_sdk::document::TixDocument;
 
 /// Print the global config document
 #[derive(clap::Args, Debug)]
-pub struct Args {
-}
+pub struct Args {}
 
 /// Prints the global config document.
 ///

--- a/tix-cli/src/tix/mod.rs
+++ b/tix-cli/src/tix/mod.rs
@@ -54,9 +54,10 @@ impl TixParser {
     pub fn parse_with_plugin_help() -> Self {
         let mut command = TixParser::command();
         if root_help_requested()
-            && let Some(section) = plugin_listing::plugins_help_section() {
-                command = command.after_help(section);
-            }
+            && let Some(section) = plugin_listing::plugins_help_section()
+        {
+            command = command.after_help(section);
+        }
         let mut matches = command.get_matches();
         match TixParser::from_arg_matches_mut(&mut matches) {
             Ok(parsed) => parsed,

--- a/tix-cli/src/tix/plugin.rs
+++ b/tix-cli/src/tix/plugin.rs
@@ -107,9 +107,9 @@ pub fn run(app: &App, args: Vec<String>) -> Result<(), SdkError> {
     command.args(&user_args);
 
     debug!(plugin = %binary.display(), "dispatching");
-    let status = command.status().map_err(|e| {
-        SdkError::Message(format!("could not exec '{}': {e}", binary.display()))
-    })?;
+    let status = command
+        .status()
+        .map_err(|e| SdkError::Message(format!("could not exec '{}': {e}", binary.display())))?;
 
     match status.code() {
         // The delta is applied only on exit 0; a failed plugin's
@@ -158,9 +158,9 @@ fn detect_current_repo(
     for name in ticket.worktrees.keys() {
         let worktree_path = ticket_root.join(name);
         let is_better = cwd.starts_with(&worktree_path)
-            && best
-                .as_ref()
-                .is_none_or(|(_, current)| worktree_path.components().count() > current.components().count());
+            && best.as_ref().is_none_or(|(_, current)| {
+                worktree_path.components().count() > current.components().count()
+            });
         if is_better {
             best = Some((ticket.worktrees[name].repo.clone(), worktree_path));
         }

--- a/tix-cli/src/tix/plugin_listing.rs
+++ b/tix-cli/src/tix/plugin_listing.rs
@@ -109,12 +109,7 @@ fn handshake_description(plugin: &Path) -> Option<String> {
 
     // Bounded read: output is untrusted, so never slurp unbounded bytes.
     let mut raw = Vec::with_capacity(512);
-    child
-        .stdout
-        .take()?
-        .take(4096)
-        .read_to_end(&mut raw)
-        .ok()?;
+    child.stdout.take()?.take(4096).read_to_end(&mut raw).ok()?;
     sanitize(&raw)
 }
 

--- a/tix-cli/src/tix/repo/add.rs
+++ b/tix-cli/src/tix/repo/add.rs
@@ -2,9 +2,9 @@
 //! `tix repo clone` (#65).
 
 use crate::tix::config::CliConfig;
-use tix_sdk::document::with_write;
 use crate::tix::repo::{RepoAlias, RepoRef};
 use crate::tix::ticket::load_cli_config;
+use tix_sdk::document::with_write;
 use tix_sdk::{Defaults, EngineConfig, SdkError};
 
 /// Register a repository in config (without cloning)
@@ -89,8 +89,8 @@ fn resolve_remote(
         return Ok((repo.to_string(), name));
     }
 
-    let defaults: Defaults =
-        tix_sdk::document::TixDocument::load(&app.context.config_path)?.section_or_default("defaults")?;
+    let defaults: Defaults = tix_sdk::document::TixDocument::load(&app.context.config_path)?
+        .section_or_default("defaults")?;
     let base = defaults
         .github_base_url
         .unwrap_or_else(|| "https://github.com".to_string());

--- a/tix-cli/src/tix/repo/clone.rs
+++ b/tix-cli/src/tix/repo/clone.rs
@@ -1,8 +1,8 @@
 //! `tix repo clone` — clone registered repositories to their code paths.
 
-use tix_sdk::document::TixDocument;
 use crate::tix::repo::RepoAlias;
-use tix_sdk::{SdkError, EngineConfig, TixError};
+use tix_sdk::document::TixDocument;
+use tix_sdk::{EngineConfig, SdkError, TixError};
 use tracing::error;
 
 /// Clone registered repositories to their code paths
@@ -43,11 +43,18 @@ pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
                 return Err(SdkError::Engine(TixError::RepoNotFound(format!(
                     "'{}' is not a registered repository (registered: {})",
                     alias.0,
-                    if registered.is_empty() { "none".to_string() } else { registered.join(", ") }
+                    if registered.is_empty() {
+                        "none".to_string()
+                    } else {
+                        registered.join(", ")
+                    }
                 ))));
             }
         }
-        args.repo_aliases.iter().map(|alias| alias.0.clone()).collect()
+        args.repo_aliases
+            .iter()
+            .map(|alias| alias.0.clone())
+            .collect()
     };
 
     let mut failed = 0usize;

--- a/tix-cli/src/tix/ticket/add.rs
+++ b/tix-cli/src/tix/ticket/add.rs
@@ -1,11 +1,11 @@
 //! `tix ticket add` — add repository worktrees to an existing ticket.
 
-use tix_sdk::document::{TixDocument, with_write};
 use crate::tix::repo::RepoAlias;
 use crate::tix::ticket::{
     TicketSharedArgs, derive_branch_name, load_ticket_config, require_ticket_root,
 };
-use tix_sdk::{SdkError, Defaults, EngineConfig, TixError};
+use tix_sdk::document::{TixDocument, with_write};
+use tix_sdk::{Defaults, EngineConfig, SdkError, TixError};
 use tracing::{error, info};
 
 /// Add repository worktrees to a ticket
@@ -58,7 +58,11 @@ pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
             return Err(SdkError::Engine(TixError::RepoNotFound(format!(
                 "'{}' is not a registered repository (registered: {})",
                 alias.0,
-                if known.is_empty() { "none".to_string() } else { known.join(", ") }
+                if known.is_empty() {
+                    "none".to_string()
+                } else {
+                    known.join(", ")
+                }
             ))));
         }
         if ticket.worktrees.contains_key(&alias.0) {
@@ -95,8 +99,7 @@ pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
                     let mut entry = toml_edit::Table::new();
                     entry["repo"] = toml_edit::value(alias.0.as_str());
                     entry["branch"] = toml_edit::value(worktree.branch.as_str());
-                    doc.doc_mut()["ticket"]["worktrees"][&alias.0] =
-                        toml_edit::Item::Table(entry);
+                    doc.doc_mut()["ticket"]["worktrees"][&alias.0] = toml_edit::Item::Table(entry);
                     Ok(())
                 })?;
                 println!("{}", root.join(&alias.0).display());

--- a/tix-cli/src/tix/ticket/destroy.rs
+++ b/tix-cli/src/tix/ticket/destroy.rs
@@ -1,8 +1,8 @@
 //! `tix ticket destroy` — prune every worktree, then delete the ticket.
 
-use tix_sdk::document::{TixDocument, with_write};
 use crate::tix::ticket::{TicketRef, TicketSharedArgs, load_ticket_config, require_ticket_root};
-use tix_sdk::{SdkError, EngineConfig, TixError, WorktreeConfig};
+use tix_sdk::document::{TixDocument, with_write};
+use tix_sdk::{EngineConfig, SdkError, TixError, WorktreeConfig};
 use tracing::{info, warn};
 
 /// Destroy a ticket: prune its worktrees, delete its directory
@@ -46,7 +46,11 @@ pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
 
     if !args.force {
         let answer = crate::tix::utils::prompt(
-            &format!("Destroy ticket '{}' at {}? [y/N]", ticket.key, root.display()),
+            &format!(
+                "Destroy ticket '{}' at {}? [y/N]",
+                ticket.key,
+                root.display()
+            ),
             Some("n"),
         )?;
         if !matches!(answer.to_lowercase().as_str(), "y" | "yes") {

--- a/tix-cli/src/tix/ticket/list.rs
+++ b/tix-cli/src/tix/ticket/list.rs
@@ -1,8 +1,8 @@
 //! `tix ticket list` — one line per ticket under the tickets directory.
 
-use tix_sdk::document::TixDocument;
 use crate::tix::ticket::load_cli_config;
 use crate::tix::utils::OutputType;
+use tix_sdk::document::TixDocument;
 use tix_sdk::{SdkError, TicketConfig};
 use tracing::warn;
 
@@ -43,7 +43,9 @@ pub fn run(app: &crate::tix::utils::App, _args: Args) -> Result<(), SdkError> {
         match parsed {
             Ok(Some(ticket)) => tickets.push(ticket),
             Ok(None) => warn!(path = %ticket_path.display(), "no [ticket] section — skipping"),
-            Err(e) => warn!(path = %ticket_path.display(), error = %e, "malformed ticket document — skipping"),
+            Err(e) => {
+                warn!(path = %ticket_path.display(), error = %e, "malformed ticket document — skipping")
+            }
         }
     }
     tickets.sort_by(|a, b| a.key.cmp(&b.key));

--- a/tix-cli/src/tix/ticket/mod.rs
+++ b/tix-cli/src/tix/ticket/mod.rs
@@ -88,13 +88,17 @@ mod branch_name_tests {
     /// Sanitization collapses punctuation runs, trims, and caps length.
     #[test]
     fn test_sanitization() {
-        assert_eq!(sanitize_description("Fix: the (login) bug!!"), "fix-the-login-bug");
+        assert_eq!(
+            sanitize_description("Fix: the (login) bug!!"),
+            "fix-the-login-bug"
+        );
         assert_eq!(sanitize_description("---"), "");
         assert!(
             sanitize_description(
                 "a very long description that goes on and on and on far past the cap"
             )
-            .len() <= 40
+            .len()
+                <= 40
         );
     }
 

--- a/tix-cli/src/tix/ticket/remove.rs
+++ b/tix-cli/src/tix/ticket/remove.rs
@@ -1,9 +1,9 @@
 //! `tix ticket remove` — remove single worktrees from a ticket without
 //! destroying it.
 
-use tix_sdk::document::{TixDocument, with_write};
 use crate::tix::ticket::{TicketSharedArgs, load_ticket_config, require_ticket_root};
-use tix_sdk::{SdkError, EngineConfig, TixError};
+use tix_sdk::document::{TixDocument, with_write};
+use tix_sdk::{EngineConfig, SdkError, TixError};
 use tracing::info;
 
 /// Remove a worktree from a ticket without destroying it
@@ -46,7 +46,11 @@ pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
                 "'{}' is not a tracked worktree of ticket '{}' (tracked: {})",
                 name,
                 ticket.key,
-                if tracked.is_empty() { "none".to_string() } else { tracked.join(", ") }
+                if tracked.is_empty() {
+                    "none".to_string()
+                } else {
+                    tracked.join(", ")
+                }
             ))
         })?;
         if !engine.configured_repositories.contains_key(&entry.repo) {

--- a/tix-cli/src/tix/ticket/setup.rs
+++ b/tix-cli/src/tix/ticket/setup.rs
@@ -1,12 +1,12 @@
 //! `tix ticket setup` — create a new ticket workspace with worktrees.
 
 use crate::tix::config::CliConfig;
-use tix_sdk::document::TixDocument;
 use crate::tix::repo::RepoAlias;
 use crate::tix::ticket::derive_branch_name;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use tix_sdk::{SdkError, Defaults, EngineConfig, TicketConfig, TixError, WorktreeConfig};
+use tix_sdk::document::TixDocument;
+use tix_sdk::{Defaults, EngineConfig, SdkError, TicketConfig, TixError, WorktreeConfig};
 use tracing::{error, info};
 
 /// Create a new ticket workspace with worktrees
@@ -62,7 +62,10 @@ pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
         aliases.sort();
         aliases
     } else if !args.repo_aliases.is_empty() {
-        args.repo_aliases.iter().map(|alias| alias.0.clone()).collect()
+        args.repo_aliases
+            .iter()
+            .map(|alias| alias.0.clone())
+            .collect()
     } else {
         defaults.repositories.clone()
     };
@@ -76,7 +79,11 @@ pub fn run(app: &crate::tix::utils::App, args: Args) -> Result<(), SdkError> {
             known.sort();
             return Err(SdkError::Engine(TixError::RepoNotFound(format!(
                 "'{alias}' is not a registered repository (registered: {})",
-                if known.is_empty() { "none".to_string() } else { known.join(", ") }
+                if known.is_empty() {
+                    "none".to_string()
+                } else {
+                    known.join(", ")
+                }
             ))));
         }
     }

--- a/tix-cli/src/tix/utils.rs
+++ b/tix-cli/src/tix/utils.rs
@@ -65,8 +65,6 @@ pub fn prompt(label: &str, default: Option<&str>) -> Result<String, tix_sdk::Sdk
     match (answer.is_empty(), default) {
         (false, _) => Ok(answer.to_string()),
         (true, Some(default)) => Ok(default.to_string()),
-        (true, None) => Err(tix_sdk::SdkError::Message(format!(
-            "{label} is required"
-        ))),
+        (true, None) => Err(tix_sdk::SdkError::Message(format!("{label} is required"))),
     }
 }

--- a/tix-engine/src/lib.rs
+++ b/tix-engine/src/lib.rs
@@ -51,7 +51,6 @@ mod types;
 mod utils;
 
 pub use types::config::EngineConfig;
-pub use utils::opens_as_git_repository;
 pub use types::defaults::Defaults;
 pub use types::errors::TixError;
 pub use types::repository::Repository;
@@ -60,3 +59,4 @@ pub use types::ticket::Ticket;
 pub use types::ticket::TicketConfig;
 pub use types::worktree::Worktree;
 pub use types::worktree::WorktreeConfig;
+pub use utils::opens_as_git_repository;

--- a/tix-engine/src/types/repository.rs
+++ b/tix-engine/src/types/repository.rs
@@ -525,7 +525,6 @@ impl Repository {
     }
 }
 
-
 /// The repo-unique name a worktree is registered under: the branch with path
 /// separators flattened. Branch uniqueness per repo (enforced by git) makes
 /// this collision-free in practice; a rare sanitization collision surfaces as
@@ -644,7 +643,9 @@ mod tests {
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
         let path = dir.path().join("worktrees/feature");
-        let worktree = repo.create_worktree("feature", "feature", &path, false).unwrap();
+        let worktree = repo
+            .create_worktree("feature", "feature", &path, false)
+            .unwrap();
 
         assert_eq!(worktree.name, "feature");
         assert_eq!(worktree.branch, "feature");
@@ -667,7 +668,9 @@ mod tests {
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
         let path = dir.path().join("worktrees/feature");
-        let worktree = repo.create_worktree("feature", "feature", &path, false).unwrap();
+        let worktree = repo
+            .create_worktree("feature", "feature", &path, false)
+            .unwrap();
 
         assert_eq!(worktree.name, "feature");
         assert_eq!(worktree.branch, "feature");
@@ -684,7 +687,8 @@ mod tests {
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
         let path = dir.path().join("worktrees/feature");
-        repo.create_worktree("feature", "feature", &path, false).unwrap();
+        repo.create_worktree("feature", "feature", &path, false)
+            .unwrap();
 
         assert!(matches!(
             repo.create_worktree("feature", "feature", &path, false),
@@ -711,10 +715,7 @@ mod tests {
         assert_eq!(worktree.name, "my-repo");
         assert_eq!(worktree.branch, "feature/JIRA-1-fix");
         let opened = git2::Repository::open(&path).unwrap();
-        assert_eq!(
-            opened.head().unwrap().shorthand(),
-            Ok("feature/JIRA-1-fix")
-        );
+        assert_eq!(opened.head().unwrap().shorthand(), Ok("feature/JIRA-1-fix"));
     }
 
     /// A sync failure propagates as an error before the worktree is created.
@@ -728,7 +729,12 @@ mod tests {
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
         assert!(matches!(
-            repo.create_worktree("feature", "feature", &dir.path().join("worktrees/feature"), false),
+            repo.create_worktree(
+                "feature",
+                "feature",
+                &dir.path().join("worktrees/feature"),
+                false
+            ),
             Err(TixError::Message(_))
         ));
     }
@@ -776,7 +782,10 @@ mod tests {
         test_helpers::orphan_worktree(&local, "feature", &dir.path().join("worktrees/feature"));
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        assert!(repo.remove_worktree(&dir.path().join("worktrees/feature"), true).is_ok());
+        assert!(
+            repo.remove_worktree(&dir.path().join("worktrees/feature"), true)
+                .is_ok()
+        );
     }
 
     /// A worktree with uncommitted changes refuses removal without `force` —
@@ -796,7 +805,10 @@ mod tests {
             Err(TixError::Message(_))
         ));
         // Force discards it.
-        assert!(repo.remove_worktree(&dir.path().join("worktrees/feature"), true).is_ok());
+        assert!(
+            repo.remove_worktree(&dir.path().join("worktrees/feature"), true)
+                .is_ok()
+        );
     }
 
     /// Removing a valid worktree succeeds and returns `Ok(())`.
@@ -809,7 +821,10 @@ mod tests {
         test_helpers::add_worktree(&local, "feature", &dir.path().join("worktrees/feature"));
         let repo = test_helpers::tix_repo(&dir.path().join("remote"), local);
 
-        assert!(repo.remove_worktree(&dir.path().join("worktrees/feature"), false).is_ok());
+        assert!(
+            repo.remove_worktree(&dir.path().join("worktrees/feature"), false)
+                .is_ok()
+        );
         assert!(!dir.path().join("worktrees/feature").exists());
     }
 

--- a/tix-sdk/src/context.rs
+++ b/tix-sdk/src/context.rs
@@ -9,9 +9,9 @@
 //! The default location is deliberately isolated in [`default_config_path`]
 //! so it can be revisited without touching resolution or call sites.
 
+use crate::error::SdkError;
 use std::ffi::OsString;
 use std::path::PathBuf;
-use crate::error::SdkError;
 use tracing::debug;
 
 /// The environment variable overriding the global config location, beaten
@@ -163,8 +163,7 @@ mod tests {
     /// With neither flag nor env var, the platform default applies.
     #[test]
     fn test_default_applies() {
-        let resolved =
-            resolve_from(None, None, Some(PathBuf::from("/from/default.toml"))).unwrap();
+        let resolved = resolve_from(None, None, Some(PathBuf::from("/from/default.toml"))).unwrap();
         assert_eq!(resolved, PathBuf::from("/from/default.toml"));
     }
 

--- a/tix-sdk/src/delta.rs
+++ b/tix-sdk/src/delta.rs
@@ -121,9 +121,8 @@ impl Delta {
     /// [`SdkError::PluginImplementation`] — a malformed delta is a bug in
     /// the plugin, reported as such, and nothing gets written.
     pub fn parse(bytes: &[u8]) -> Result<Self, SdkError> {
-        serde_json::from_slice(bytes).map_err(|e| {
-            SdkError::PluginImplementation(format!("malformed config delta: {e}"))
-        })
+        serde_json::from_slice(bytes)
+            .map_err(|e| SdkError::PluginImplementation(format!("malformed config delta: {e}")))
     }
 
     /// Applies every op to `document` as path traversals over the
@@ -178,10 +177,7 @@ impl Delta {
 /// Maps a JSON value to a TOML value by its text form: `1` → integer,
 /// `1.0` → float, string/bool direct, arrays and objects recurse, and the
 /// tagged `{"$datetime": "…"}` form becomes a native TOML datetime.
-fn json_to_toml_value(
-    value: &serde_json::Value,
-    path: &str,
-) -> Result<toml_edit::Value, SdkError> {
+fn json_to_toml_value(value: &serde_json::Value, path: &str) -> Result<toml_edit::Value, SdkError> {
     use serde_json::Value as Json;
     Ok(match value {
         Json::String(s) => toml_edit::Value::from(s.as_str()),
@@ -296,7 +292,8 @@ mod tests {
     /// keys — comments and foreign tables survive.
     #[test]
     fn test_apply_preserves_untouched_content() {
-        let source = "# keep this comment\n[engine]\n\n[myplugin]\nbranch = \"old\" # inline\nkeep = 1\n";
+        let source =
+            "# keep this comment\n[engine]\n\n[myplugin]\nbranch = \"old\" # inline\nkeep = 1\n";
         let mut document = TixDocument::parse(source).unwrap();
         let delta = Delta::new(DeltaTarget::Global)
             .set("myplugin.branch", "new")
@@ -346,8 +343,8 @@ mod tests {
             Delta::parse(b"{not json"),
             Err(SdkError::PluginImplementation(_))
         ));
-        let delta = Delta::parse(br#"{"target":"global","ops":[{"set":"p.x","value":null}]}"#)
-            .unwrap();
+        let delta =
+            Delta::parse(br#"{"target":"global","ops":[{"set":"p.x","value":null}]}"#).unwrap();
         assert!(matches!(
             delta.apply_ops(&mut TixDocument::empty()),
             Err(SdkError::PluginImplementation(_))

--- a/tix-sdk/src/discovery.rs
+++ b/tix-sdk/src/discovery.rs
@@ -14,11 +14,10 @@
 //!   starting points — a near-miss (e.g. a subdirectory of a ticket) errors
 //!   rather than re-walking.
 
-use std::path::{Path, PathBuf};
 use crate::error::SdkError;
+use std::path::{Path, PathBuf};
 use tix_engine::TixError;
 use tracing::debug;
-
 
 /// A `--ticket` argument: one flag, two forms, disambiguated by shape
 /// (`design/spec.md` §4).
@@ -43,8 +42,7 @@ impl std::str::FromStr for TicketRef {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let path = Path::new(s);
-        let is_path_shape =
-            s == "." || s == ".." || path.is_absolute() || s.contains(['/', '\\']);
+        let is_path_shape = s == "." || s == ".." || path.is_absolute() || s.contains(['/', '\\']);
         if is_path_shape {
             Ok(TicketRef::Path(path.to_path_buf()))
         } else {
@@ -73,7 +71,8 @@ pub fn is_ticket_root(path: &Path) -> bool {
 /// it is absolute and still names the same directory as the process cwd;
 /// otherwise the process cwd is the fallback.
 pub fn logical_cwd() -> Result<PathBuf, SdkError> {
-    let process_cwd = std::env::current_dir().map_err(|e| SdkError::Engine(TixError::IoError(e)))?;
+    let process_cwd =
+        std::env::current_dir().map_err(|e| SdkError::Engine(TixError::IoError(e)))?;
     if let Some(pwd) = std::env::var_os("PWD") {
         let pwd = PathBuf::from(pwd);
         if pwd.is_absolute() && same_directory(&pwd, &process_cwd) {
@@ -339,8 +338,7 @@ mod tests {
         let ticket = dir.path().join("JIRA-1");
         make_ticket_root(&ticket);
 
-        let resolved =
-            resolve_override(&TicketRef::Id("JIRA-1".to_string()), dir.path()).unwrap();
+        let resolved = resolve_override(&TicketRef::Id("JIRA-1".to_string()), dir.path()).unwrap();
         assert_eq!(resolved, ticket);
     }
 

--- a/tix-sdk/src/document.rs
+++ b/tix-sdk/src/document.rs
@@ -18,11 +18,11 @@
 //! Written in `tix-cli` first; promoted here (#96) so plugins parse
 //! documents identically.
 
+use crate::error::SdkError;
 use serde::de::DeserializeOwned;
 use std::fmt;
 use std::fs::File;
 use std::path::{Path, PathBuf};
-use crate::error::SdkError;
 use tracing::debug;
 
 /// A parsed tix config document: a format-preserving TOML DOM with typed
@@ -453,8 +453,7 @@ retries = 3
                 let path = path.clone();
                 std::thread::spawn(move || {
                     with_write(&path, |doc| {
-                        doc.doc_mut()["section"][format!("key{i}")] =
-                            toml_edit::value(i as i64);
+                        doc.doc_mut()["section"][format!("key{i}")] = toml_edit::value(i as i64);
                         Ok(())
                     })
                     .unwrap();
@@ -467,7 +466,10 @@ retries = 3
 
         let text = std::fs::read_to_string(&path).unwrap();
         for i in 0..8 {
-            assert!(text.contains(&format!("key{i} = {i}")), "missing key{i} in:\n{text}");
+            assert!(
+                text.contains(&format!("key{i} = {i}")),
+                "missing key{i} in:\n{text}"
+            );
         }
     }
 }

--- a/tix-sdk/src/host.rs
+++ b/tix-sdk/src/host.rs
@@ -243,9 +243,7 @@ pub fn prescan_globals(args: &[String]) -> (PrescannedGlobals, Vec<String>) {
     let mut iter = args.iter().peekable();
     while let Some(arg) = iter.next() {
         let mut take_value = |inline: Option<&str>| -> Option<String> {
-            inline
-                .map(str::to_string)
-                .or_else(|| iter.next().cloned())
+            inline.map(str::to_string).or_else(|| iter.next().cloned())
         };
         match arg.split_once('=') {
             _ if arg == "-v" || arg == "--verbose" => globals.verbose = true,
@@ -272,10 +270,17 @@ mod prescan_tests {
     /// in order.
     #[test]
     fn test_prescan_extracts_globals() {
-        let args: Vec<String> = ["deploy", "--verbose", "--output", "json", "target", "--force"]
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
+        let args: Vec<String> = [
+            "deploy",
+            "--verbose",
+            "--output",
+            "json",
+            "target",
+            "--force",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
         let (globals, user_args) = prescan_globals(&args);
         assert!(globals.verbose);
         assert_eq!(globals.output.as_deref(), Some("json"));
@@ -358,8 +363,7 @@ mod tests {
     /// Ticket context is optional and its absence is load-bearing.
     #[test]
     fn test_ticket_optional() {
-        let context =
-            HostContext::from_args(args(&["--tix-config", "/cfg.toml"])).unwrap();
+        let context = HostContext::from_args(args(&["--tix-config", "/cfg.toml"])).unwrap();
         assert!(context.ticket_root.is_none());
         assert!(context.require_ticket().is_err());
 

--- a/tix-sdk/src/spawn.rs
+++ b/tix-sdk/src/spawn.rs
@@ -40,7 +40,10 @@ mod tests {
     #[test]
     fn test_pins_ticket() {
         let command = tix_command(Path::new("/tickets/JIRA-1"));
-        let args: Vec<_> = command.get_args().map(|a| a.to_string_lossy().to_string()).collect();
+        let args: Vec<_> = command
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
         assert_eq!(args, vec!["--ticket", "/tickets/JIRA-1"]);
         assert_eq!(command.get_program(), "tix");
     }


### PR DESCRIPTION
Post-merge cleanup to get `main` green for the 3.0 release. The v3.0 stack was rebase-merged with admin bypass, so PR checks never ran on the final state of `main`; `just ci` locally surfaced two lint failures, and dependencies are bumped while we're at it.

- **rustfmt drift** across 26 files (mostly `tix-sdk` and `tix-engine`) — fixed with `cargo fmt`, no semantic changes
- **unused `pytest` import** in `pytix/tests/test_stub.py` (ruff F401)
- **`cargo update`**: all transitive deps to latest semver-compatible (clap 4.6.6, libgit2-sys 1.9.7+1.9.7, time 0.3.55 — the broken publish that forced the 0.3.47 pin is fixed upstream)
- **pyo3 0.28.3 → 0.29.2** — supersedes dependabot #134, which should auto-close once this lands
- **`uv sync --upgrade`** for the python lockfile

With all of this, `just ci` passes end to end locally: fmt, clippy (`-D warnings`), license year, version consistency (all crates at 3.0.0), rust tests + doctests, and pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)